### PR TITLE
Update week1_setup.ipynb

### DIFF
--- a/notebooks/week1/week1_setup.ipynb
+++ b/notebooks/week1/week1_setup.ipynb
@@ -300,6 +300,7 @@
     "        cwd=str(project_root),\n",
     "        capture_output=True,\n",
     "        text=True,\n",
+    "        encoding=\"utf-8\",\n",
     "        timeout=10\n",
     "    )\n",
     "    \n",


### PR DESCRIPTION
forced utf-8 encoding in current container check to avoid charmap UnicodeDecodeError under Windows