### PR TITLE
fix(docs): correct health check endpoint URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ uv sync
 docker compose up --build -d
 
 # 5. Verify everything works
-curl http://localhost:8000/health
+curl http://localhost:8000/api/v1/health
 ```
 
 ### **📚 Weekly Learning Path**
@@ -468,7 +468,7 @@ arxiv-paper-curator/
 
 | Endpoint | Method | Description | Week |
 |----------|--------|-------------|------|
-| `/health` | GET | Service health check | Week 1 |
+| `/api/v1/health` | GET | Service health check | Week 1 |
 | `/api/v1/papers` | GET | List stored papers | Week 2 |
 | `/api/v1/papers/{id}` | GET | Get specific paper | Week 2 |
 | `/api/v1/search` | POST | BM25 keyword search | Week 3 |


### PR DESCRIPTION
## Summary

Fixes #5 — the Quick Start step 5 used `/health` but the actual endpoint is `/api/v1/health`.

The health router is mounted with `prefix="/api/v1"` in `src/main.py`:
```python
app.include_router(ping.router, prefix="/api/v1")  # Health check endpoint
```

So `curl http://localhost:8000/health` returns a 404, while `curl http://localhost:8000/api/v1/health` works correctly.

## Changes

- `README.md` Quick Start step 5: `/health` → `/api/v1/health`
- `README.md` API Endpoints Reference table: `/health` → `/api/v1/health`