### PR TITLE
fix: Correct health check endpoint in Quick Start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ uv sync
 docker compose up --build -d
 
 # 5. Verify everything works
-curl http://localhost:8000/health
+curl http://localhost:8000/api/v1/health
 ```
 
 ### **📚 Weekly Learning Path**


### PR DESCRIPTION
## Summary
- Fixed the health check curl command in Quick Start section from `/health` to `/api/v1/health`
- The FastAPI router is mounted with prefix `/api/v1` (see src/main.py:114), so the actual endpoint is `/api/v1/health`

## Test plan
- [ ] Verify the endpoint `/api/v1/health` returns a 200 OK response when services are running
- [ ] Confirm the old endpoint `/health` returns 404

🤖 Generated with [Claude Code](https://claude.ai/code)