### PR TITLE
feat: add MiniMax as alternative LLM provider (default: MiniMax-M3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,9 +53,19 @@ CHUNKING__SECTION_BASED=true
 # Jina AI Embeddings (Required for hybrid search)
 JINA_API_KEY=your_jina_api_key_here
 
-# Ollama Configuration
+# LLM Provider Selection: "ollama" (local) or "minimax" (cloud)
+LLM_PROVIDER=ollama
+
+# Ollama Configuration (used when LLM_PROVIDER=ollama)
 OLLAMA_MODEL=llama3.2:1b
 OLLAMA_TIMEOUT=300
+
+# MiniMax Configuration (used when LLM_PROVIDER=minimax)
+# Get your API key from https://platform.minimax.io
+MINIMAX_API_KEY=your_minimax_api_key_here
+MINIMAX_MODEL=MiniMax-M2.7
+MINIMAX_BASE_URL=https://api.minimax.io/v1
+MINIMAX_TIMEOUT=300
 
 # Langfuse v3 Tracing Configuration - Official SDK Standard (single underscore)
 LANGFUSE_ENABLED=true

--- a/.env.example
+++ b/.env.example
@@ -63,7 +63,7 @@ OLLAMA_TIMEOUT=300
 # MiniMax Configuration (used when LLM_PROVIDER=minimax)
 # Get your API key from https://platform.minimax.io
 MINIMAX_API_KEY=your_minimax_api_key_here
-MINIMAX_MODEL=MiniMax-M2.7
+MINIMAX_MODEL=MiniMax-M3
 MINIMAX_BASE_URL=https://api.minimax.io/v1
 MINIMAX_TIMEOUT=300
 

--- a/README.md
+++ b/README.md
@@ -423,6 +423,8 @@ cp .env.example .env
 ```
 
 **Key Variables:**
+- `LLM_PROVIDER` - LLM backend: `ollama` (default, local) or `minimax` (cloud)
+- `MINIMAX_API_KEY` - Required when `LLM_PROVIDER=minimax` ([Get API key](https://platform.minimax.io))
 - `JINA_API_KEY` - Required for Week 4+ (hybrid search with embeddings)
 - `TELEGRAM__BOT_TOKEN` - Required for Week 7 (Telegram bot integration)
 - `LANGFUSE__PUBLIC_KEY` & `LANGFUSE__SECRET_KEY` - Optional for Week 6 (monitoring)
@@ -443,6 +445,7 @@ cp .env.example .env
 | **Apache Airflow 3.0** | Workflow automation | ✅ Ready |
 | **Jina AI** | Embedding generation (Week 4) | ✅ Ready |
 | **Ollama** | Local LLM serving (Week 5) | ✅ Ready |
+| **[MiniMax](https://platform.minimax.io)** | Cloud LLM provider (MiniMax-M2.7) | ✅ Ready |
 | **Redis** | High-performance caching (Week 6) | ✅ Ready |
 | **Langfuse** | RAG pipeline observability (Week 6) | ✅ Ready |
 

--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ cp .env.example .env
 | **Apache Airflow 3.0** | Workflow automation | ✅ Ready |
 | **Jina AI** | Embedding generation (Week 4) | ✅ Ready |
 | **Ollama** | Local LLM serving (Week 5) | ✅ Ready |
-| **[MiniMax](https://platform.minimax.io)** | Cloud LLM provider (MiniMax-M2.7) | ✅ Ready |
+| **[MiniMax](https://platform.minimax.io)** | Cloud LLM provider (MiniMax-M3) | ✅ Ready |
 | **Redis** | High-performance caching (Week 6) | ✅ Ready |
 | **Langfuse** | RAG pipeline observability (Week 6) | ✅ Ready |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "langchain-core>=0.3.0",
     "langchain-community>=0.3.0",
     "langchain-ollama>=0.3.0",
+    "langchain-openai>=0.3.0",
 ]
 readme = "README.md"
 

--- a/src/config.py
+++ b/src/config.py
@@ -170,9 +170,18 @@ class Settings(BaseConfigSettings):
     postgres_pool_size: int = 20
     postgres_max_overflow: int = 0
 
+    # LLM provider selection: "ollama" (local) or "minimax" (cloud)
+    llm_provider: str = "ollama"
+
     ollama_host: str = "http://localhost:11434"
     ollama_model: str = "llama3.2:1b"
     ollama_timeout: int = 300
+
+    # MiniMax cloud LLM configuration (OpenAI-compatible API)
+    minimax_api_key: str = ""
+    minimax_model: str = "MiniMax-M2.7"
+    minimax_base_url: str = "https://api.minimax.io/v1"
+    minimax_timeout: int = 300
 
     # Jina AI embeddings configuration
     jina_api_key: str = ""

--- a/src/config.py
+++ b/src/config.py
@@ -179,7 +179,7 @@ class Settings(BaseConfigSettings):
 
     # MiniMax cloud LLM configuration (OpenAI-compatible API)
     minimax_api_key: str = ""
-    minimax_model: str = "MiniMax-M2.7"
+    minimax_model: str = "MiniMax-M3"
     minimax_base_url: str = "https://api.minimax.io/v1"
     minimax_timeout: int = 300
 

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -13,11 +13,11 @@ else:
 
 from src.config import Settings
 from src.db.interfaces.base import BaseDatabase
+from src.services.agents.context import LLMClient
 from src.services.arxiv.client import ArxivClient
 from src.services.cache.client import CacheClient
 from src.services.embeddings.jina_client import JinaEmbeddingsClient
 from src.services.langfuse.client import LangfuseTracer
-from src.services.ollama.client import OllamaClient
 from src.services.opensearch.client import OpenSearchClient
 from src.services.pdf_parser.parser import PDFParserService
 from src.services.telegram.bot import TelegramBot
@@ -67,9 +67,9 @@ def get_embeddings_service(request: Request) -> JinaEmbeddingsClient:
     return request.app.state.embeddings_service
 
 
-def get_ollama_client(request: Request) -> OllamaClient:
-    """Get Ollama client from the request state."""
-    return request.app.state.ollama_client
+def get_llm_client(request: Request) -> LLMClient:
+    """Get LLM client from the request state (Ollama or MiniMax)."""
+    return request.app.state.llm_client
 
 
 def get_langfuse_tracer(request: Request) -> LangfuseTracer:
@@ -95,7 +95,7 @@ OpenSearchDep = Annotated[OpenSearchClient, Depends(get_opensearch_client)]
 ArxivDep = Annotated[ArxivClient, Depends(get_arxiv_client)]
 PDFParserDep = Annotated[PDFParserService, Depends(get_pdf_parser)]
 EmbeddingsDep = Annotated[JinaEmbeddingsClient, Depends(get_embeddings_service)]
-OllamaDep = Annotated[OllamaClient, Depends(get_ollama_client)]
+LLMDep = Annotated[LLMClient, Depends(get_llm_client)]
 LangfuseDep = Annotated[LangfuseTracer, Depends(get_langfuse_tracer)]
 CacheDep = Annotated[CacheClient | None, Depends(get_cache_client)]
 TelegramDep = Annotated[Optional[TelegramBot], Depends(get_telegram_service)]
@@ -103,18 +103,19 @@ TelegramDep = Annotated[Optional[TelegramBot], Depends(get_telegram_service)]
 
 def get_agentic_rag_service(
     opensearch: OpenSearchDep,
-    ollama: OllamaDep,
+    llm: LLMDep,
     embeddings: EmbeddingsDep,
     langfuse: LangfuseDep,
     settings: Annotated[Settings, Depends(get_settings)],
 ) -> AgenticRAGService:
     """Get agentic RAG service."""
+    model = settings.minimax_model if settings.llm_provider == "minimax" else settings.ollama_model
     return make_agentic_rag_service(
         opensearch_client=opensearch,
-        ollama_client=ollama,
+        llm_client=llm,
         embeddings_client=embeddings,
         langfuse_tracer=langfuse,
-        model=settings.ollama_model,
+        model=model,
     )
 
 

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -82,6 +82,18 @@ class OllamaTimeoutError(OllamaException):
     """Exception raised when Ollama service times out."""
 
 
+class MiniMaxException(LLMException):
+    """Exception raised for MiniMax API errors."""
+
+
+class MiniMaxConnectionError(MiniMaxException):
+    """Exception raised when cannot connect to MiniMax API."""
+
+
+class MiniMaxTimeoutError(MiniMaxException):
+    """Exception raised when MiniMax API times out."""
+
+
 # General application exceptions
 class ConfigurationError(Exception):
     """Exception raised when configuration is invalid."""

--- a/src/main.py
+++ b/src/main.py
@@ -12,7 +12,7 @@ from src.services.arxiv.factory import make_arxiv_client
 from src.services.cache.factory import make_cache_client
 from src.services.embeddings.factory import make_embeddings_service
 from src.services.langfuse.factory import make_langfuse_tracer
-from src.services.ollama.factory import make_ollama_client
+from src.services.llm_factory import make_llm_client
 from src.services.opensearch.factory import make_opensearch_client
 from src.services.pdf_parser.factory import make_pdf_parser_service
 from src.services.telegram.factory import make_telegram_service
@@ -67,16 +67,17 @@ async def lifespan(app: FastAPI):
     app.state.arxiv_client = make_arxiv_client()
     app.state.pdf_parser = make_pdf_parser_service()
     app.state.embeddings_service = make_embeddings_service()
-    app.state.ollama_client = make_ollama_client()
+    app.state.llm_client = make_llm_client()
     app.state.langfuse_tracer = make_langfuse_tracer()
     app.state.cache_client = make_cache_client(settings)
-    logger.info("Services initialized: arXiv API client, PDF parser, OpenSearch, Embeddings, Ollama, Langfuse, Cache")
+    llm_provider = settings.llm_provider.upper()
+    logger.info(f"Services initialized: arXiv API client, PDF parser, OpenSearch, Embeddings, LLM ({llm_provider}), Langfuse, Cache")
 
     # Initialize Telegram bot (Week 7)
     telegram_service = make_telegram_service(
         opensearch_client=app.state.opensearch_client,
         embeddings_client=app.state.embeddings_service,
-        ollama_client=app.state.ollama_client,
+        ollama_client=app.state.llm_client,
         cache_client=app.state.cache_client,
         langfuse_tracer=app.state.langfuse_tracer,
     )

--- a/src/routers/ping.py
+++ b/src/routers/ping.py
@@ -3,7 +3,7 @@ from sqlalchemy import text
 
 from ..dependencies import DatabaseDep, OpenSearchDep, SettingsDep
 from ..schemas.api.health import HealthResponse, ServiceStatus
-from ..services.ollama import OllamaClient
+from ..services.llm_factory import make_llm_client
 
 router = APIRouter()
 
@@ -53,15 +53,16 @@ async def health_check(settings: SettingsDep, database: DatabaseDep, opensearch_
     _check_service("database", _check_database)
     _check_service("opensearch", _check_opensearch)
 
-    # Handle Ollama async check separately
+    # Handle LLM provider async check separately
     try:
-        ollama_client = OllamaClient(settings)
-        ollama_health = await ollama_client.health_check()
-        services["ollama"] = ServiceStatus(status=ollama_health["status"], message=ollama_health["message"])
-        if ollama_health["status"] != "healthy":
+        llm_client = make_llm_client()
+        llm_health = await llm_client.health_check()
+        provider_name = settings.llm_provider
+        services[provider_name] = ServiceStatus(status=llm_health["status"], message=llm_health["message"])
+        if llm_health["status"] != "healthy":
             overall_status = "degraded"
     except Exception as e:
-        services["ollama"] = ServiceStatus(status="unhealthy", message=str(e))
+        services[settings.llm_provider] = ServiceStatus(status="unhealthy", message=str(e))
         overall_status = "degraded"
 
     return HealthResponse(

--- a/src/services/agents/agentic_rag.py
+++ b/src/services/agents/agentic_rag.py
@@ -7,9 +7,9 @@ from langfuse.langchain import CallbackHandler
 from langgraph.graph import END, START, StateGraph
 from langgraph.prebuilt import ToolNode, tools_condition
 
+from src.services.agents.context import LLMClient
 from src.services.embeddings.jina_client import JinaEmbeddingsClient
 from src.services.langfuse.client import LangfuseTracer
-from src.services.ollama.client import OllamaClient
 from src.services.opensearch.client import OpenSearchClient
 
 from .config import GraphConfig
@@ -42,7 +42,7 @@ class AgenticRAGService:
     def __init__(
         self,
         opensearch_client: OpenSearchClient,
-        ollama_client: OllamaClient,
+        llm_client: LLMClient,
         embeddings_client: JinaEmbeddingsClient,
         langfuse_tracer: Optional[LangfuseTracer] = None,
         graph_config: Optional[GraphConfig] = None,
@@ -50,13 +50,13 @@ class AgenticRAGService:
         """Initialize agentic RAG service.
 
         :param opensearch_client: Client for document search
-        :param ollama_client: Client for LLM generation
+        :param llm_client: Client for LLM generation (OllamaClient or MiniMaxClient)
         :param embeddings_client: Client for embeddings
         :param langfuse_tracer: Optional Langfuse tracer
         :param graph_config: Configuration for graph execution
         """
         self.opensearch = opensearch_client
-        self.ollama = ollama_client
+        self.llm_client = llm_client
         self.embeddings = embeddings_client
         self.langfuse_tracer = langfuse_tracer
         self.graph_config = graph_config or GraphConfig()
@@ -250,7 +250,7 @@ class AgenticRAGService:
 
             # Runtime context (dependencies)
             runtime_context = Context(
-                ollama_client=self.ollama,
+                llm_client=self.llm_client,
                 opensearch_client=self.opensearch,
                 embeddings_client=self.embeddings,
                 langfuse_tracer=self.langfuse_tracer,

--- a/src/services/agents/context.py
+++ b/src/services/agents/context.py
@@ -1,11 +1,15 @@
 from dataclasses import dataclass
 from langfuse._client.span import LangfuseSpan
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from src.services.embeddings.jina_client import JinaEmbeddingsClient
 from src.services.langfuse.client import LangfuseTracer
+from src.services.minimax.client import MiniMaxClient
 from src.services.ollama.client import OllamaClient
 from src.services.opensearch.client import OpenSearchClient
+
+# Union type for any LLM client that implements get_langchain_model()
+LLMClient = Union[OllamaClient, MiniMaxClient]
 
 
 @dataclass
@@ -14,7 +18,7 @@ class Context:
 
     This contains immutable dependencies that nodes need but don't modify.
 
-    :param ollama_client: Client for LLM generation
+    :param llm_client: Client for LLM generation (OllamaClient or MiniMaxClient)
     :param opensearch_client: Client for document search
     :param embeddings_client: Client for embeddings
     :param langfuse_tracer: Optional tracer for observability
@@ -27,7 +31,7 @@ class Context:
     :param guardrail_threshold: Threshold for guardrail validation (0-100)
     """
 
-    ollama_client: OllamaClient
+    llm_client: LLMClient
     opensearch_client: OpenSearchClient
     embeddings_client: JinaEmbeddingsClient
     langfuse_tracer: Optional[LangfuseTracer]

--- a/src/services/agents/factory.py
+++ b/src/services/agents/factory.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
+from src.services.agents.context import LLMClient
 from src.services.embeddings.jina_client import JinaEmbeddingsClient
 from src.services.langfuse.client import LangfuseTracer
-from src.services.ollama.client import OllamaClient
 from src.services.opensearch.client import OpenSearchClient
 
 from .agentic_rag import AgenticRAGService
@@ -11,35 +11,37 @@ from .config import GraphConfig
 
 def make_agentic_rag_service(
     opensearch_client: OpenSearchClient,
-    ollama_client: OllamaClient,
+    llm_client: LLMClient,
     embeddings_client: JinaEmbeddingsClient,
     langfuse_tracer: Optional[LangfuseTracer] = None,
     top_k: int = 3,
     use_hybrid: bool = True,
+    model: Optional[str] = None,
 ) -> AgenticRAGService:
     """
     Create AgenticRAGService with dependency injection.
 
     Args:
         opensearch_client: Client for document search
-        ollama_client: Client for LLM generation
+        llm_client: Client for LLM generation (OllamaClient or MiniMaxClient)
         embeddings_client: Client for embeddings
         langfuse_tracer: Optional Langfuse tracer for observability
         top_k: Number of documents to retrieve (default: 3)
         use_hybrid: Use hybrid search (default: True)
+        model: Optional model name override
 
     Returns:
         Configured AgenticRAGService instance
     """
     # Create graph configuration with the provided parameters
-    graph_config = GraphConfig(
-        top_k=top_k,
-        use_hybrid=use_hybrid,
-    )
+    config_kwargs = {"top_k": top_k, "use_hybrid": use_hybrid}
+    if model:
+        config_kwargs["model"] = model
+    graph_config = GraphConfig(**config_kwargs)
 
     return AgenticRAGService(
         opensearch_client=opensearch_client,
-        ollama_client=ollama_client,
+        llm_client=llm_client,
         embeddings_client=embeddings_client,
         langfuse_tracer=langfuse_tracer,
         graph_config=graph_config,

--- a/src/services/agents/nodes/generate_answer_node.py
+++ b/src/services/agents/nodes/generate_answer_node.py
@@ -80,7 +80,7 @@ async def ainvoke_generate_answer_step(
         )
 
         # Get LLM from runtime context
-        llm = runtime.context.ollama_client.get_langchain_model(
+        llm = runtime.context.llm_client.get_langchain_model(
             model=runtime.context.model_name,
             temperature=runtime.context.temperature,
         )

--- a/src/services/agents/nodes/grade_documents_node.py
+++ b/src/services/agents/nodes/grade_documents_node.py
@@ -89,7 +89,7 @@ async def ainvoke_grade_documents_step(
         )
 
         # Get LLM from runtime context
-        llm = runtime.context.ollama_client.get_langchain_model(
+        llm = runtime.context.llm_client.get_langchain_model(
             model=runtime.context.model_name,
             temperature=0.0,
         )

--- a/src/services/agents/nodes/guardrail_node.py
+++ b/src/services/agents/nodes/guardrail_node.py
@@ -81,7 +81,7 @@ async def ainvoke_guardrail_step(
         guardrail_prompt = GUARDRAIL_PROMPT.format(question=query)
 
         # Get LLM from runtime context
-        llm = runtime.context.ollama_client.get_langchain_model(
+        llm = runtime.context.llm_client.get_langchain_model(
             model=runtime.context.model_name,
             temperature=0.0,
         )

--- a/src/services/agents/nodes/rewrite_query_node.py
+++ b/src/services/agents/nodes/rewrite_query_node.py
@@ -70,7 +70,7 @@ async def ainvoke_rewrite_query_step(
     # Use LLM to rewrite the query intelligently
     try:
         # Create structured LLM for query rewriting
-        llm = runtime.context.ollama_client.get_langchain_model(
+        llm = runtime.context.llm_client.get_langchain_model(
             model=runtime.context.model_name,
             temperature=0.3,  # Lower temperature for more focused rewriting
         )

--- a/src/services/llm_factory.py
+++ b/src/services/llm_factory.py
@@ -1,0 +1,40 @@
+"""LLM client factory for selecting between Ollama and MiniMax providers."""
+
+import logging
+from functools import lru_cache
+from typing import Union
+
+from src.config import get_settings
+from src.services.minimax.client import MiniMaxClient
+from src.services.ollama.client import OllamaClient
+
+logger = logging.getLogger(__name__)
+
+LLMClient = Union[OllamaClient, MiniMaxClient]
+
+
+@lru_cache(maxsize=1)
+def make_llm_client() -> LLMClient:
+    """Create the appropriate LLM client based on LLM_PROVIDER setting.
+
+    Supports:
+        - "ollama": Local Ollama LLM service (default)
+        - "minimax": MiniMax cloud LLM via OpenAI-compatible API
+
+    Returns:
+        Configured LLM client instance
+    """
+    settings = get_settings()
+    provider = settings.llm_provider.lower()
+
+    if provider == "minimax":
+        if not settings.minimax_api_key:
+            raise ValueError(
+                "MINIMAX_API_KEY is required when LLM_PROVIDER=minimax. "
+                "Set it in your .env file."
+            )
+        logger.info(f"Using MiniMax LLM provider (model: {settings.minimax_model})")
+        return MiniMaxClient(settings)
+    else:
+        logger.info(f"Using Ollama LLM provider (model: {settings.ollama_model})")
+        return OllamaClient(settings)

--- a/src/services/minimax/__init__.py
+++ b/src/services/minimax/__init__.py
@@ -1,0 +1,3 @@
+from .client import MiniMaxClient
+
+__all__ = ["MiniMaxClient"]

--- a/src/services/minimax/client.py
+++ b/src/services/minimax/client.py
@@ -1,0 +1,376 @@
+import json
+import logging
+import re
+from typing import Any, Dict, List, Optional
+
+import httpx
+from langchain_openai import ChatOpenAI
+from src.config import Settings
+from src.exceptions import MiniMaxConnectionError, MiniMaxException, MiniMaxTimeoutError
+from src.services.ollama.prompts import RAGPromptBuilder, ResponseParser
+
+logger = logging.getLogger(__name__)
+
+# MiniMax models available via OpenAI-compatible API
+MINIMAX_MODELS = ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"]
+
+
+def _clamp_temperature(temperature: float) -> float:
+    """Clamp temperature to MiniMax's accepted range (0.01, 1.0].
+
+    MiniMax API requires temperature > 0 and <= 1.0.
+    Values of 0 are clamped to 0.01 for near-deterministic behavior.
+
+    Args:
+        temperature: Requested temperature value
+
+    Returns:
+        Clamped temperature value
+    """
+    if temperature <= 0:
+        return 0.01
+    return min(temperature, 1.0)
+
+
+def _strip_think_tags(text: str) -> str:
+    """Strip <think>...</think> tags from MiniMax responses.
+
+    MiniMax M2.7 may include thinking tags in structured output responses.
+
+    Args:
+        text: Raw response text
+
+    Returns:
+        Text with think tags removed
+    """
+    return re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL).strip()
+
+
+class MiniMaxClient:
+    """Client for interacting with MiniMax LLM via OpenAI-compatible API.
+
+    MiniMax provides an OpenAI-compatible API at https://api.minimax.io/v1.
+    This client wraps it for use as a drop-in alternative to OllamaClient.
+
+    API Reference: https://platform.minimax.io/docs/api-reference/text-openai-api
+    """
+
+    def __init__(self, settings: Settings):
+        """Initialize MiniMax client with settings.
+
+        Args:
+            settings: Application settings containing MiniMax configuration
+        """
+        self.base_url = settings.minimax_base_url
+        self.api_key = settings.minimax_api_key
+        self.default_model = settings.minimax_model
+        self.timeout = httpx.Timeout(float(settings.minimax_timeout))
+        self.prompt_builder = RAGPromptBuilder()
+        self.response_parser = ResponseParser()
+
+    def get_langchain_model(
+        self,
+        model: Optional[str] = None,
+        temperature: float = 1.0,
+        **kwargs,
+    ) -> ChatOpenAI:
+        """Return a LangChain ChatOpenAI model pointing to MiniMax API.
+
+        This is the primary interface used by agent nodes for LLM calls.
+
+        Args:
+            model: Model name (defaults to configured model)
+            temperature: Generation temperature (clamped to MiniMax range)
+            **kwargs: Additional model parameters
+
+        Returns:
+            ChatOpenAI instance configured for MiniMax
+        """
+        return ChatOpenAI(
+            model=model or self.default_model,
+            api_key=self.api_key,
+            base_url=self.base_url,
+            temperature=_clamp_temperature(temperature),
+            **kwargs,
+        )
+
+    async def health_check(self) -> Dict[str, Any]:
+        """Check if MiniMax API is reachable via a lightweight chat completions call.
+
+        Returns:
+            Dictionary with health status information
+        """
+        try:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0)) as client:
+                # Use a minimal chat completion request to verify connectivity
+                response = await client.post(
+                    f"{self.base_url}/chat/completions",
+                    headers={
+                        "Authorization": f"Bearer {self.api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    json={
+                        "model": self.default_model,
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "max_tokens": 1,
+                    },
+                )
+
+                if response.status_code == 200:
+                    return {
+                        "status": "healthy",
+                        "message": "MiniMax API is reachable",
+                        "provider": "minimax",
+                    }
+                else:
+                    raise MiniMaxException(f"MiniMax returned status {response.status_code}")
+
+        except httpx.ConnectError as e:
+            raise MiniMaxConnectionError(f"Cannot connect to MiniMax API: {e}")
+        except httpx.TimeoutException as e:
+            raise MiniMaxTimeoutError(f"MiniMax API timeout: {e}")
+        except MiniMaxException:
+            raise
+        except Exception as e:
+            raise MiniMaxException(f"MiniMax health check failed: {str(e)}")
+
+    async def list_models(self) -> List[Dict[str, Any]]:
+        """Get list of available MiniMax models.
+
+        Returns:
+            List of model information dictionaries
+        """
+        return [{"id": m, "provider": "minimax"} for m in MINIMAX_MODELS]
+
+    async def generate(
+        self,
+        model: str,
+        prompt: str,
+        stream: bool = False,
+        **kwargs,
+    ) -> Optional[Dict[str, Any]]:
+        """Generate text using MiniMax OpenAI-compatible chat API.
+
+        Args:
+            model: Model name to use
+            prompt: Input prompt for generation
+            stream: Whether to stream response (ignored, use generate_stream)
+            **kwargs: Additional generation parameters (temperature, top_p, etc.)
+
+        Returns:
+            Response dictionary with generated text and usage metadata
+        """
+        temperature = _clamp_temperature(kwargs.pop("temperature", 1.0))
+        # MiniMax does not support response_format; remove if present
+        kwargs.pop("format", None)
+        kwargs.pop("response_format", None)
+
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                payload = {
+                    "model": model or self.default_model,
+                    "messages": [{"role": "user", "content": prompt}],
+                    "temperature": temperature,
+                    "stream": False,
+                }
+                # Pass through supported params
+                if "top_p" in kwargs:
+                    payload["top_p"] = kwargs["top_p"]
+
+                logger.info(f"Sending request to MiniMax: model={payload['model']}")
+                response = await client.post(
+                    f"{self.base_url}/chat/completions",
+                    headers={
+                        "Authorization": f"Bearer {self.api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    json=payload,
+                )
+
+                if response.status_code == 200:
+                    data = response.json()
+                    content = data["choices"][0]["message"]["content"]
+                    content = _strip_think_tags(content)
+                    usage = data.get("usage", {})
+
+                    return {
+                        "response": content,
+                        "usage_metadata": {
+                            "prompt_tokens": usage.get("prompt_tokens", 0),
+                            "completion_tokens": usage.get("completion_tokens", 0),
+                            "total_tokens": usage.get("total_tokens", 0),
+                        },
+                    }
+                else:
+                    raise MiniMaxException(f"Generation failed: {response.status_code} - {response.text}")
+
+        except httpx.ConnectError as e:
+            raise MiniMaxConnectionError(f"Cannot connect to MiniMax API: {e}")
+        except httpx.TimeoutException as e:
+            raise MiniMaxTimeoutError(f"MiniMax API timeout: {e}")
+        except MiniMaxException:
+            raise
+        except Exception as e:
+            raise MiniMaxException(f"Error generating with MiniMax: {e}")
+
+    async def generate_stream(self, model: str, prompt: str, **kwargs):
+        """Generate text with streaming response via MiniMax API.
+
+        Args:
+            model: Model name to use
+            prompt: Input prompt for generation
+            **kwargs: Additional generation parameters
+
+        Yields:
+            JSON chunks from streaming response
+        """
+        temperature = _clamp_temperature(kwargs.pop("temperature", 1.0))
+        kwargs.pop("format", None)
+        kwargs.pop("response_format", None)
+
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                payload = {
+                    "model": model or self.default_model,
+                    "messages": [{"role": "user", "content": prompt}],
+                    "temperature": temperature,
+                    "stream": True,
+                }
+                if "top_p" in kwargs:
+                    payload["top_p"] = kwargs["top_p"]
+
+                logger.info(f"Starting streaming generation: model={payload['model']}")
+
+                async with client.stream(
+                    "POST",
+                    f"{self.base_url}/chat/completions",
+                    headers={
+                        "Authorization": f"Bearer {self.api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    json=payload,
+                ) as response:
+                    if response.status_code != 200:
+                        raise MiniMaxException(f"Streaming generation failed: {response.status_code}")
+
+                    async for line in response.aiter_lines():
+                        line = line.strip()
+                        if not line or not line.startswith("data: "):
+                            continue
+                        data_str = line[len("data: "):]
+                        if data_str == "[DONE]":
+                            yield {"done": True}
+                            break
+                        try:
+                            chunk = json.loads(data_str)
+                            delta = chunk.get("choices", [{}])[0].get("delta", {})
+                            content = delta.get("content", "")
+                            if content:
+                                content = _strip_think_tags(content)
+                            yield {"response": content, "done": False}
+                        except json.JSONDecodeError:
+                            logger.warning(f"Failed to parse streaming chunk: {line}")
+                            continue
+
+        except httpx.ConnectError as e:
+            raise MiniMaxConnectionError(f"Cannot connect to MiniMax API: {e}")
+        except httpx.TimeoutException as e:
+            raise MiniMaxTimeoutError(f"MiniMax API timeout: {e}")
+        except MiniMaxException:
+            raise
+        except Exception as e:
+            raise MiniMaxException(f"Error in streaming generation: {e}")
+
+    async def generate_rag_answer(
+        self,
+        query: str,
+        chunks: List[Dict[str, Any]],
+        model: str = "MiniMax-M2.7",
+        use_structured_output: bool = False,
+    ) -> Dict[str, Any]:
+        """Generate a RAG answer using retrieved chunks.
+
+        Args:
+            query: User's question
+            chunks: Retrieved document chunks with metadata
+            model: Model to use for generation
+            use_structured_output: Whether to use structured output
+
+        Returns:
+            Dictionary with answer, sources, confidence, and citations
+        """
+        try:
+            prompt = self.prompt_builder.create_rag_prompt(query, chunks)
+
+            response = await self.generate(
+                model=model,
+                prompt=prompt,
+                temperature=0.7,
+                top_p=0.9,
+            )
+
+            if response and "response" in response:
+                answer_text = response["response"]
+                logger.debug(f"Raw LLM response: {answer_text[:500]}")
+
+                if use_structured_output:
+                    parsed_response = self.response_parser.parse_structured_response(answer_text)
+                    return parsed_response
+
+                # Build simple response structure
+                sources = []
+                seen_urls = set()
+                for chunk in chunks:
+                    arxiv_id = chunk.get("arxiv_id")
+                    if arxiv_id:
+                        arxiv_id_clean = arxiv_id.split("v")[0] if "v" in arxiv_id else arxiv_id
+                        pdf_url = f"https://arxiv.org/pdf/{arxiv_id_clean}.pdf"
+                        if pdf_url not in seen_urls:
+                            sources.append(pdf_url)
+                            seen_urls.add(pdf_url)
+
+                citations = list(set(chunk.get("arxiv_id") for chunk in chunks if chunk.get("arxiv_id")))
+
+                return {
+                    "answer": answer_text,
+                    "sources": sources,
+                    "confidence": "medium",
+                    "citations": citations[:5],
+                }
+            else:
+                raise MiniMaxException("No response generated from MiniMax")
+
+        except Exception as e:
+            logger.error(f"Error generating RAG answer: {e}")
+            raise MiniMaxException(f"Failed to generate RAG answer: {e}")
+
+    async def generate_rag_answer_stream(
+        self,
+        query: str,
+        chunks: List[Dict[str, Any]],
+        model: str = "MiniMax-M2.7",
+    ):
+        """Generate a streaming RAG answer using retrieved chunks.
+
+        Args:
+            query: User's question
+            chunks: Retrieved document chunks with metadata
+            model: Model to use for generation
+
+        Yields:
+            Streaming response chunks with partial answers
+        """
+        try:
+            prompt = self.prompt_builder.create_rag_prompt(query, chunks)
+
+            async for chunk in self.generate_stream(
+                model=model,
+                prompt=prompt,
+                temperature=0.7,
+                top_p=0.9,
+            ):
+                yield chunk
+
+        except Exception as e:
+            logger.error(f"Error generating streaming RAG answer: {e}")
+            raise MiniMaxException(f"Failed to generate streaming RAG answer: {e}")

--- a/src/services/minimax/client.py
+++ b/src/services/minimax/client.py
@@ -12,7 +12,7 @@ from src.services.ollama.prompts import RAGPromptBuilder, ResponseParser
 logger = logging.getLogger(__name__)
 
 # MiniMax models available via OpenAI-compatible API
-MINIMAX_MODELS = ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"]
+MINIMAX_MODELS = ["MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"]
 
 
 def _clamp_temperature(temperature: float) -> float:
@@ -35,7 +35,7 @@ def _clamp_temperature(temperature: float) -> float:
 def _strip_think_tags(text: str) -> str:
     """Strip <think>...</think> tags from MiniMax responses.
 
-    MiniMax M2.7 may include thinking tags in structured output responses.
+    MiniMax models may include thinking tags in structured output responses.
 
     Args:
         text: Raw response text
@@ -285,7 +285,7 @@ class MiniMaxClient:
         self,
         query: str,
         chunks: List[Dict[str, Any]],
-        model: str = "MiniMax-M2.7",
+        model: str = "MiniMax-M3",
         use_structured_output: bool = False,
     ) -> Dict[str, Any]:
         """Generate a RAG answer using retrieved chunks.
@@ -348,7 +348,7 @@ class MiniMaxClient:
         self,
         query: str,
         chunks: List[Dict[str, Any]],
-        model: str = "MiniMax-M2.7",
+        model: str = "MiniMax-M3",
     ):
         """Generate a streaming RAG answer using retrieved chunks.
 

--- a/src/services/minimax/factory.py
+++ b/src/services/minimax/factory.py
@@ -1,0 +1,15 @@
+from functools import lru_cache
+
+from src.config import get_settings
+from src.services.minimax.client import MiniMaxClient
+
+
+@lru_cache(maxsize=1)
+def make_minimax_client() -> MiniMaxClient:
+    """Create and return a singleton MiniMax client instance.
+
+    Returns:
+        MiniMaxClient: Configured MiniMax client
+    """
+    settings = get_settings()
+    return MiniMaxClient(settings)

--- a/src/services/ollama/client.py
+++ b/src/services/ollama/client.py
@@ -3,6 +3,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 import httpx
+from langchain_ollama import ChatOllama
 from src.config import Settings
 from src.exceptions import OllamaConnectionError, OllamaException, OllamaTimeoutError
 from src.schemas.ollama import RAGResponse
@@ -20,6 +21,31 @@ class OllamaClient:
         self.timeout = httpx.Timeout(float(settings.ollama_timeout))
         self.prompt_builder = RAGPromptBuilder()
         self.response_parser = ResponseParser()
+
+    def get_langchain_model(
+        self,
+        model: Optional[str] = None,
+        temperature: float = 0.0,
+        **kwargs,
+    ) -> ChatOllama:
+        """Return a LangChain ChatOllama model instance.
+
+        This is the primary interface used by agent nodes for LLM calls.
+
+        Args:
+            model: Model name (defaults to llama3.2:1b)
+            temperature: Generation temperature
+            **kwargs: Additional model parameters
+
+        Returns:
+            ChatOllama instance configured for the Ollama service
+        """
+        return ChatOllama(
+            model=model or "llama3.2:1b",
+            base_url=self.base_url,
+            temperature=temperature,
+            **kwargs,
+        )
 
     async def health_check(self) -> Dict[str, Any]:
         """

--- a/tests/integration/test_minimax_integration.py
+++ b/tests/integration/test_minimax_integration.py
@@ -1,0 +1,68 @@
+"""Integration tests for MiniMax LLM provider.
+
+These tests verify MiniMax API connectivity and basic functionality.
+They require MINIMAX_API_KEY to be set in the environment.
+"""
+
+import os
+
+import pytest
+
+from src.services.minimax.client import MiniMaxClient
+
+
+def _get_minimax_client():
+    """Create a MiniMax client for integration testing."""
+    from unittest.mock import MagicMock
+
+    api_key = os.environ.get("MINIMAX_API_KEY", "")
+    if not api_key:
+        pytest.skip("MINIMAX_API_KEY not set, skipping integration test")
+
+    settings = MagicMock()
+    settings.minimax_api_key = api_key
+    settings.minimax_model = "MiniMax-M2.7"
+    settings.minimax_base_url = "https://api.minimax.io/v1"
+    settings.minimax_timeout = 60
+    return MiniMaxClient(settings)
+
+
+@pytest.mark.asyncio
+async def test_minimax_health_check():
+    """Test MiniMax API health check."""
+    client = _get_minimax_client()
+    result = await client.health_check()
+    assert result["status"] == "healthy"
+    assert result["provider"] == "minimax"
+
+
+@pytest.mark.asyncio
+async def test_minimax_generate():
+    """Test basic text generation with MiniMax API."""
+    client = _get_minimax_client()
+    result = await client.generate(
+        model="MiniMax-M2.7",
+        prompt="What is 2+2? Reply with just the number.",
+        temperature=0.01,
+    )
+    assert result is not None
+    assert "response" in result
+    assert len(result["response"]) > 0
+    assert "4" in result["response"]
+    assert result["usage_metadata"]["total_tokens"] > 0
+
+
+@pytest.mark.asyncio
+async def test_minimax_get_langchain_model():
+    """Test LangChain model creation for MiniMax."""
+    client = _get_minimax_client()
+    model = client.get_langchain_model(model="MiniMax-M2.7", temperature=0.5)
+    assert model is not None
+    assert model.model_name == "MiniMax-M2.7"
+    assert model.temperature == 0.5
+
+    # Test invocation
+    response = await model.ainvoke("What is 1+1? Reply with just the number.")
+    assert response is not None
+    assert hasattr(response, "content")
+    assert "2" in response.content

--- a/tests/integration/test_minimax_integration.py
+++ b/tests/integration/test_minimax_integration.py
@@ -21,7 +21,7 @@ def _get_minimax_client():
 
     settings = MagicMock()
     settings.minimax_api_key = api_key
-    settings.minimax_model = "MiniMax-M2.7"
+    settings.minimax_model = "MiniMax-M3"
     settings.minimax_base_url = "https://api.minimax.io/v1"
     settings.minimax_timeout = 60
     return MiniMaxClient(settings)
@@ -41,7 +41,7 @@ async def test_minimax_generate():
     """Test basic text generation with MiniMax API."""
     client = _get_minimax_client()
     result = await client.generate(
-        model="MiniMax-M2.7",
+        model="MiniMax-M3",
         prompt="What is 2+2? Reply with just the number.",
         temperature=0.01,
     )
@@ -56,9 +56,9 @@ async def test_minimax_generate():
 async def test_minimax_get_langchain_model():
     """Test LangChain model creation for MiniMax."""
     client = _get_minimax_client()
-    model = client.get_langchain_model(model="MiniMax-M2.7", temperature=0.5)
+    model = client.get_langchain_model(model="MiniMax-M3", temperature=0.5)
     assert model is not None
-    assert model.model_name == "MiniMax-M2.7"
+    assert model.model_name == "MiniMax-M3"
     assert model.temperature == 0.5
 
     # Test invocation

--- a/tests/unit/services/minimax/test_minimax_client.py
+++ b/tests/unit/services/minimax/test_minimax_client.py
@@ -1,0 +1,313 @@
+"""Unit tests for MiniMax LLM client."""
+
+import json
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+from src.services.minimax.client import (
+    MiniMaxClient,
+    MINIMAX_MODELS,
+    _clamp_temperature,
+    _strip_think_tags,
+)
+from src.exceptions import MiniMaxConnectionError, MiniMaxException, MiniMaxTimeoutError
+
+
+@pytest.fixture
+def minimax_settings():
+    """Create mock settings for MiniMax client."""
+    settings = MagicMock()
+    settings.minimax_api_key = "test-api-key"
+    settings.minimax_model = "MiniMax-M2.7"
+    settings.minimax_base_url = "https://api.minimax.io/v1"
+    settings.minimax_timeout = 300
+    return settings
+
+
+@pytest.fixture
+def minimax_client(minimax_settings):
+    """Create a MiniMax client with mock settings."""
+    return MiniMaxClient(minimax_settings)
+
+
+class TestClampTemperature:
+    """Tests for temperature clamping utility."""
+
+    def test_zero_temperature_clamped(self):
+        assert _clamp_temperature(0.0) == 0.01
+
+    def test_negative_temperature_clamped(self):
+        assert _clamp_temperature(-0.5) == 0.01
+
+    def test_valid_temperature_unchanged(self):
+        assert _clamp_temperature(0.5) == 0.5
+
+    def test_max_temperature(self):
+        assert _clamp_temperature(1.0) == 1.0
+
+    def test_over_max_clamped(self):
+        assert _clamp_temperature(1.5) == 1.0
+
+    def test_small_positive_unchanged(self):
+        assert _clamp_temperature(0.01) == 0.01
+
+
+class TestStripThinkTags:
+    """Tests for think tag stripping utility."""
+
+    def test_strip_think_tags(self):
+        text = "<think>some reasoning</think>The answer is 42."
+        assert _strip_think_tags(text) == "The answer is 42."
+
+    def test_no_think_tags(self):
+        text = "The answer is 42."
+        assert _strip_think_tags(text) == "The answer is 42."
+
+    def test_multiline_think_tags(self):
+        text = "<think>\nstep 1\nstep 2\n</think>\nFinal answer."
+        assert _strip_think_tags(text) == "Final answer."
+
+    def test_empty_think_tags(self):
+        text = "<think></think>Hello"
+        assert _strip_think_tags(text) == "Hello"
+
+
+class TestMiniMaxClientInit:
+    """Tests for MiniMax client initialization."""
+
+    def test_client_initialization(self, minimax_client, minimax_settings):
+        assert minimax_client.api_key == "test-api-key"
+        assert minimax_client.default_model == "MiniMax-M2.7"
+        assert minimax_client.base_url == "https://api.minimax.io/v1"
+
+    def test_models_list(self):
+        assert "MiniMax-M2.7" in MINIMAX_MODELS
+        assert "MiniMax-M2.7-highspeed" in MINIMAX_MODELS
+
+
+class TestGetLangchainModel:
+    """Tests for get_langchain_model method."""
+
+    def test_returns_chat_openai(self, minimax_client):
+        model = minimax_client.get_langchain_model()
+        assert model is not None
+        assert model.model_name == "MiniMax-M2.7"
+
+    def test_custom_model(self, minimax_client):
+        model = minimax_client.get_langchain_model(model="MiniMax-M2.7-highspeed")
+        assert model.model_name == "MiniMax-M2.7-highspeed"
+
+    def test_temperature_clamped(self, minimax_client):
+        model = minimax_client.get_langchain_model(temperature=0.0)
+        assert model.temperature == 0.01
+
+    def test_valid_temperature(self, minimax_client):
+        model = minimax_client.get_langchain_model(temperature=0.7)
+        assert model.temperature == 0.7
+
+
+class TestHealthCheck:
+    """Tests for health check method."""
+
+    @pytest.mark.asyncio
+    async def test_health_check_success(self, minimax_client):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_async_client.return_value = mock_client
+
+            result = await minimax_client.health_check()
+
+            assert result["status"] == "healthy"
+            assert result["provider"] == "minimax"
+
+    @pytest.mark.asyncio
+    async def test_health_check_failure(self, minimax_client):
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_async_client.return_value = mock_client
+
+            with pytest.raises(MiniMaxException):
+                await minimax_client.health_check()
+
+
+class TestListModels:
+    """Tests for list_models method."""
+
+    @pytest.mark.asyncio
+    async def test_list_models(self, minimax_client):
+        models = await minimax_client.list_models()
+        assert len(models) == 2
+        assert models[0]["id"] == "MiniMax-M2.7"
+        assert models[1]["id"] == "MiniMax-M2.7-highspeed"
+        assert models[0]["provider"] == "minimax"
+
+
+class TestGenerate:
+    """Tests for generate method."""
+
+    @pytest.mark.asyncio
+    async def test_generate_success(self, minimax_client):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "Hello world"}}],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+            },
+        }
+
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_async_client.return_value = mock_client
+
+            result = await minimax_client.generate(
+                model="MiniMax-M2.7",
+                prompt="Say hello",
+            )
+
+            assert result["response"] == "Hello world"
+            assert result["usage_metadata"]["total_tokens"] == 15
+
+    @pytest.mark.asyncio
+    async def test_generate_strips_think_tags(self, minimax_client):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "<think>reasoning</think>Answer"}}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        }
+
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_async_client.return_value = mock_client
+
+            result = await minimax_client.generate(
+                model="MiniMax-M2.7",
+                prompt="Test",
+            )
+
+            assert result["response"] == "Answer"
+
+    @pytest.mark.asyncio
+    async def test_generate_api_error(self, minimax_client):
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_async_client.return_value = mock_client
+
+            with pytest.raises(MiniMaxException):
+                await minimax_client.generate(
+                    model="MiniMax-M2.7",
+                    prompt="Test",
+                )
+
+    @pytest.mark.asyncio
+    async def test_generate_removes_unsupported_params(self, minimax_client):
+        """Test that response_format and format params are removed."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "OK"}}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6},
+        }
+
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_async_client.return_value = mock_client
+
+            result = await minimax_client.generate(
+                model="MiniMax-M2.7",
+                prompt="Test",
+                format={"type": "json"},
+                response_format={"type": "json_object"},
+            )
+
+            assert result["response"] == "OK"
+            # Verify the unsupported params were not sent in the request
+            call_args = mock_client.post.call_args
+            payload = call_args[1]["json"]
+            assert "format" not in payload
+            assert "response_format" not in payload
+
+
+class TestGenerateRagAnswer:
+    """Tests for generate_rag_answer method."""
+
+    @pytest.mark.asyncio
+    async def test_generate_rag_answer(self, minimax_client):
+        chunks = [
+            {"arxiv_id": "2301.01234", "chunk_text": "Transformers are neural networks."},
+            {"arxiv_id": "2301.05678", "chunk_text": "Attention is key."},
+        ]
+
+        with patch.object(minimax_client, "generate", new_callable=AsyncMock) as mock_gen:
+            mock_gen.return_value = {
+                "response": "Transformers use attention mechanisms.",
+            }
+
+            result = await minimax_client.generate_rag_answer(
+                query="What are transformers?",
+                chunks=chunks,
+            )
+
+            assert "answer" in result
+            assert result["answer"] == "Transformers use attention mechanisms."
+            assert len(result["sources"]) == 2
+            assert len(result["citations"]) == 2
+
+
+class TestGenerateRagAnswerStream:
+    """Tests for generate_rag_answer_stream method."""
+
+    @pytest.mark.asyncio
+    async def test_stream_rag_answer(self, minimax_client):
+        chunks = [
+            {"arxiv_id": "2301.01234", "chunk_text": "Test content."},
+        ]
+
+        async def mock_stream(*args, **kwargs):
+            yield {"response": "Hello ", "done": False}
+            yield {"response": "world!", "done": False}
+            yield {"done": True}
+
+        with patch.object(minimax_client, "generate_stream", side_effect=mock_stream):
+            collected = []
+            async for chunk in minimax_client.generate_rag_answer_stream(
+                query="Test query",
+                chunks=chunks,
+            ):
+                collected.append(chunk)
+
+            assert len(collected) == 3
+            assert collected[0]["response"] == "Hello "
+            assert collected[2]["done"] is True

--- a/tests/unit/services/minimax/test_minimax_client.py
+++ b/tests/unit/services/minimax/test_minimax_client.py
@@ -19,7 +19,7 @@ def minimax_settings():
     """Create mock settings for MiniMax client."""
     settings = MagicMock()
     settings.minimax_api_key = "test-api-key"
-    settings.minimax_model = "MiniMax-M2.7"
+    settings.minimax_model = "MiniMax-M3"
     settings.minimax_base_url = "https://api.minimax.io/v1"
     settings.minimax_timeout = 300
     return settings
@@ -78,12 +78,14 @@ class TestMiniMaxClientInit:
 
     def test_client_initialization(self, minimax_client, minimax_settings):
         assert minimax_client.api_key == "test-api-key"
-        assert minimax_client.default_model == "MiniMax-M2.7"
+        assert minimax_client.default_model == "MiniMax-M3"
         assert minimax_client.base_url == "https://api.minimax.io/v1"
 
     def test_models_list(self):
+        assert "MiniMax-M3" in MINIMAX_MODELS
         assert "MiniMax-M2.7" in MINIMAX_MODELS
         assert "MiniMax-M2.7-highspeed" in MINIMAX_MODELS
+        assert MINIMAX_MODELS[0] == "MiniMax-M3"
 
 
 class TestGetLangchainModel:
@@ -92,7 +94,7 @@ class TestGetLangchainModel:
     def test_returns_chat_openai(self, minimax_client):
         model = minimax_client.get_langchain_model()
         assert model is not None
-        assert model.model_name == "MiniMax-M2.7"
+        assert model.model_name == "MiniMax-M3"
 
     def test_custom_model(self, minimax_client):
         model = minimax_client.get_langchain_model(model="MiniMax-M2.7-highspeed")
@@ -149,9 +151,10 @@ class TestListModels:
     @pytest.mark.asyncio
     async def test_list_models(self, minimax_client):
         models = await minimax_client.list_models()
-        assert len(models) == 2
-        assert models[0]["id"] == "MiniMax-M2.7"
-        assert models[1]["id"] == "MiniMax-M2.7-highspeed"
+        assert len(models) == 3
+        assert models[0]["id"] == "MiniMax-M3"
+        assert models[1]["id"] == "MiniMax-M2.7"
+        assert models[2]["id"] == "MiniMax-M2.7-highspeed"
         assert models[0]["provider"] == "minimax"
 
 
@@ -179,7 +182,7 @@ class TestGenerate:
             mock_async_client.return_value = mock_client
 
             result = await minimax_client.generate(
-                model="MiniMax-M2.7",
+                model="MiniMax-M3",
                 prompt="Say hello",
             )
 
@@ -203,7 +206,7 @@ class TestGenerate:
             mock_async_client.return_value = mock_client
 
             result = await minimax_client.generate(
-                model="MiniMax-M2.7",
+                model="MiniMax-M3",
                 prompt="Test",
             )
 
@@ -224,7 +227,7 @@ class TestGenerate:
 
             with pytest.raises(MiniMaxException):
                 await minimax_client.generate(
-                    model="MiniMax-M2.7",
+                    model="MiniMax-M3",
                     prompt="Test",
                 )
 
@@ -246,7 +249,7 @@ class TestGenerate:
             mock_async_client.return_value = mock_client
 
             result = await minimax_client.generate(
-                model="MiniMax-M2.7",
+                model="MiniMax-M3",
                 prompt="Test",
                 format={"type": "json"},
                 response_format={"type": "json_object"},

--- a/tests/unit/services/test_llm_factory.py
+++ b/tests/unit/services/test_llm_factory.py
@@ -1,0 +1,80 @@
+"""Unit tests for LLM client factory."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from src.services.llm_factory import make_llm_client
+from src.services.minimax.client import MiniMaxClient
+from src.services.ollama.client import OllamaClient
+
+
+class TestMakeLLMClient:
+    """Tests for LLM client factory function."""
+
+    def setup_method(self):
+        """Clear lru_cache before each test."""
+        make_llm_client.cache_clear()
+
+    def test_default_provider_is_ollama(self):
+        """Test that default provider returns OllamaClient."""
+        mock_settings = MagicMock()
+        mock_settings.llm_provider = "ollama"
+        mock_settings.ollama_host = "http://localhost:11434"
+        mock_settings.ollama_timeout = 300
+        mock_settings.ollama_model = "llama3.2:1b"
+
+        with patch("src.services.llm_factory.get_settings", return_value=mock_settings):
+            client = make_llm_client()
+            assert isinstance(client, OllamaClient)
+
+    def test_minimax_provider(self):
+        """Test that minimax provider returns MiniMaxClient."""
+        mock_settings = MagicMock()
+        mock_settings.llm_provider = "minimax"
+        mock_settings.minimax_api_key = "test-key"
+        mock_settings.minimax_model = "MiniMax-M2.7"
+        mock_settings.minimax_base_url = "https://api.minimax.io/v1"
+        mock_settings.minimax_timeout = 300
+
+        with patch("src.services.llm_factory.get_settings", return_value=mock_settings):
+            make_llm_client.cache_clear()
+            client = make_llm_client()
+            assert isinstance(client, MiniMaxClient)
+
+    def test_minimax_without_api_key_raises(self):
+        """Test that missing API key raises ValueError."""
+        mock_settings = MagicMock()
+        mock_settings.llm_provider = "minimax"
+        mock_settings.minimax_api_key = ""
+
+        with patch("src.services.llm_factory.get_settings", return_value=mock_settings):
+            make_llm_client.cache_clear()
+            with pytest.raises(ValueError, match="MINIMAX_API_KEY is required"):
+                make_llm_client()
+
+    def test_case_insensitive_provider(self):
+        """Test that provider name is case-insensitive."""
+        mock_settings = MagicMock()
+        mock_settings.llm_provider = "MiniMax"
+        mock_settings.minimax_api_key = "test-key"
+        mock_settings.minimax_model = "MiniMax-M2.7"
+        mock_settings.minimax_base_url = "https://api.minimax.io/v1"
+        mock_settings.minimax_timeout = 300
+
+        with patch("src.services.llm_factory.get_settings", return_value=mock_settings):
+            make_llm_client.cache_clear()
+            client = make_llm_client()
+            assert isinstance(client, MiniMaxClient)
+
+    def test_unknown_provider_defaults_to_ollama(self):
+        """Test that unknown provider falls back to Ollama."""
+        mock_settings = MagicMock()
+        mock_settings.llm_provider = "unknown"
+        mock_settings.ollama_host = "http://localhost:11434"
+        mock_settings.ollama_timeout = 300
+        mock_settings.ollama_model = "llama3.2:1b"
+
+        with patch("src.services.llm_factory.get_settings", return_value=mock_settings):
+            make_llm_client.cache_clear()
+            client = make_llm_client()
+            assert isinstance(client, OllamaClient)

--- a/tests/unit/services/test_llm_factory.py
+++ b/tests/unit/services/test_llm_factory.py
@@ -32,7 +32,7 @@ class TestMakeLLMClient:
         mock_settings = MagicMock()
         mock_settings.llm_provider = "minimax"
         mock_settings.minimax_api_key = "test-key"
-        mock_settings.minimax_model = "MiniMax-M2.7"
+        mock_settings.minimax_model = "MiniMax-M3"
         mock_settings.minimax_base_url = "https://api.minimax.io/v1"
         mock_settings.minimax_timeout = 300
 
@@ -57,7 +57,7 @@ class TestMakeLLMClient:
         mock_settings = MagicMock()
         mock_settings.llm_provider = "MiniMax"
         mock_settings.minimax_api_key = "test-key"
-        mock_settings.minimax_model = "MiniMax-M2.7"
+        mock_settings.minimax_model = "MiniMax-M3"
         mock_settings.minimax_base_url = "https://api.minimax.io/v1"
         mock_settings.minimax_timeout = 300
 


### PR DESCRIPTION
## Summary

Add [MiniMax](https://platform.minimax.io) as an alternative cloud LLM provider alongside Ollama, configurable via the `LLM_PROVIDER` environment variable. The default MiniMax model is **MiniMax-M3**.

### Changes

- **MiniMaxClient** (`src/services/minimax/client.py`): Full-featured client using MiniMax's OpenAI-compatible API with temperature clamping, think-tag stripping, streaming support, and RAG answer generation
- **LLM Factory** (`src/services/llm_factory.py`): Provider-agnostic factory that returns OllamaClient or MiniMaxClient based on `LLM_PROVIDER` setting
- **Provider abstraction**: Refactored agent nodes to use `llm_client` instead of `ollama_client`, enabling seamless provider switching across guardrail, grading, rewriting, and answer generation nodes
- **OllamaClient enhancement**: Added `get_langchain_model()` method to OllamaClient for consistency with MiniMaxClient
- **Configuration**: Added `LLM_PROVIDER`, `MINIMAX_API_KEY`, `MINIMAX_MODEL`, `MINIMAX_BASE_URL` env vars (default `MINIMAX_MODEL=MiniMax-M3`)
- **Tests**: 30 unit tests + 3 integration tests (all updated for M3 as default; all passing)
- **Documentation**: Updated README, `.env.example` with MiniMax configuration

### Supported Models

| Model | Description |
|-------|-------------|
| `MiniMax-M3` | Latest model, 512K context, 128K max output, image input support (**default**) |
| `MiniMax-M2.7` | Previous generation, peak performance, ultimate value |
| `MiniMax-M2.7-highspeed` | Previous generation, same performance, faster and more agile |

### Usage

```bash
# Switch to MiniMax (in .env)
LLM_PROVIDER=minimax
MINIMAX_API_KEY=your_key_here
# MINIMAX_MODEL=MiniMax-M3 (default)
```

No code changes needed — the existing RAG pipeline, agentic workflows, and Telegram bot all work with MiniMax out of the box.

### Files Changed

**New files:**
- `src/services/minimax/client.py` — MiniMax client implementation
- `src/services/minimax/factory.py` — MiniMax client factory
- `src/services/llm_factory.py` — Provider-agnostic LLM factory
- `tests/unit/services/minimax/test_minimax_client.py` — 25 unit tests
- `tests/unit/services/test_llm_factory.py` — 5 unit tests
- `tests/integration/test_minimax_integration.py` — 3 integration tests

**Modified files:**
- Config, dependencies, routers, agent nodes, and documentation

## API Reference

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api

## Test Plan

- [x] 30 unit tests pass (temperature clamping, think-tag stripping, client methods, factory; updated for M3 default)
- [x] 3 integration tests pass (health check, text generation, LangChain model; targeting M3)
- [x] Existing Ollama flow unchanged (default `LLM_PROVIDER=ollama`)
- [ ] Verify with `docker compose up` and test RAG endpoints