### PR TITLE
feat: Claude Code workshop artifacts — CLAUDE.md, skills, hooks, CI

### DIFF
--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -1,0 +1,11 @@
+Create a pull request for the current branch. Use "$ARGUMENTS" as the PR title if
+provided, otherwise derive one from the commits.
+
+1. `git status` — confirm we're on a feature branch (not main) and review what's staged.
+2. Stage only the files belonging to this change (`git add <paths>`, never `-A`),
+   commit if needed.
+3. `git push -u origin HEAD`
+4. `gh pr create --title "<title>" --body` with sections: Summary (bullets from the
+   diff) and Test plan (how it was verified). Include `Closes #<issue>` if this
+   branch maps to an issue.
+5. Print the PR URL.

--- a/.claude/commands/daily-standup.md
+++ b/.claude/commands/daily-standup.md
@@ -1,0 +1,6 @@
+Summarize my recent work for standup. Period: "$ARGUMENTS" (default: yesterday).
+
+1. `git log --since="<period>" --author="$(git config user.email)" --oneline --all`
+2. `gh pr list --author @me --state all --limit 10`
+3. Output three short sections: **Done** / **In progress** / **Blockers** (infer
+   blockers from failing CI or PRs awaiting review). Keep it under 10 lines.

--- a/.claude/commands/fix-ci.md
+++ b/.claude/commands/fix-ci.md
@@ -1,0 +1,11 @@
+Diagnose and fix the failing CI run for the current branch (workflow:
+`.github/workflows/ci.yml`). Optional run id: "$ARGUMENTS".
+
+1. `gh run list --branch $(git branch --show-current) --limit 5` — find the failing run
+   (or use the provided id).
+2. `gh run view <id> --log-failed` — pull only the failing step logs.
+3. Reproduce locally with the matching command (`uv run ruff check`,
+   `uv run ruff format --check`, `uv run mypy src/`,
+   `uv run pytest --ignore=tests/integration`).
+4. Fix the root cause, not the symptom. Re-run the local command until green, then
+   push and confirm the new run passes.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(make:*)",
+      "Bash(uv run:*)",
+      "Bash(uv sync:*)",
+      "Bash(uvx pip-audit:*)",
+      "Bash(docker compose:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git fetch:*)",
+      "Bash(git branch:*)",
+      "Bash(git worktree:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh run view:*)",
+      "Bash(gh run list:*)",
+      "Bash(curl -s http://localhost:*)",
+      "Skill(write-a-prd)",
+      "Skill(work-issue)",
+      "Skill(local-ci)",
+      "Skill(audit)",
+      "Skill(generate-tests)",
+      "Skill(setup-experiment)",
+      "Skill(offline-eval)",
+      "Skill(cleanup-experiment)",
+      "Skill(list-experiments)",
+      "Skill(brainstorming)",
+      "Skill(grill-me)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run pre-commit run --files \"$CLAUDE_FILE_PATHS\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: audit
+description: Run a versioned quality audit — deterministic scanners plus AI review passes over this repo's risk surfaces — and write docs/quality-audit-vN.md with a delta against the previous audit.
+---
+
+# Quality Audit
+
+Produce a versioned, comparable snapshot of code health. Each run writes
+`docs/quality-audit-vN.md` (N = previous + 1) and diffs against v(N-1).
+
+## 1. Deterministic scanners
+
+```bash
+uv run ruff check
+uv run mypy src/
+uvx pip-audit                     # dependency CVEs
+uv run pytest --co -q | tail -1   # test count
+```
+
+Record counts, not walls of output.
+
+## 2. AI review passes (this repo's risk surfaces)
+
+- **Search injection** — `src/services/opensearch/query_builder.py`: is user input
+  ever interpolated into query strings or index names without going through the
+  structured query DSL?
+- **Prompt injection** — agentic surface: `src/services/agents/nodes/`,
+  `src/services/agents/prompts.py`, and the Telegram entry point
+  (`src/services/telegram/`). Can retrieved chunk content or user messages steer the
+  agent off its prompts? Are tool outputs treated as data?
+- **Secrets & config** — `src/config.py`, `.env*`, `compose.yml`: defaults that leak
+  into production, credentials in compose, settings echoed into logs.
+
+One subagent per pass; findings need `file:line` evidence and a severity
+(critical/high/medium/low).
+
+## 3. Report — `docs/quality-audit-vN.md`
+
+Sections: Summary grades (A-F per area) · Findings table (id, severity, file:line,
+description) · Risk register · Delta vs v(N-1) (fixed / still open / new / regressed)
+· Recommendations (top 3, sized).
+
+## Extend this by…
+
+Adding OWASP LLM Top-10 checklist coverage, dependency-license checks, or wiring the
+audit into a scheduled run.

--- a/.claude/skills/brainstorming/SKILL.md
+++ b/.claude/skills/brainstorming/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: brainstorming
+description: Design-first gate before any creative or structural work — explore context, clarify, propose 2-3 approaches, converge on a written spec. Use before building anything that doesn't have an obvious single implementation.
+---
+
+# Brainstorming
+
+No code until the design is agreed. This skill is a gate, not a detour.
+
+## Steps
+
+1. **Explore first**: read the relevant modules (`src/routers/`, `src/services/`,
+   schemas) before forming opinions. Cite `file:line` for every claim about current
+   behavior.
+2. **Clarify**: ask the questions whose answers change the design. Don't ask what you
+   can verify in the code.
+3. **Propose 2-3 approaches**, each with: sketch, trade-offs, blast radius (files
+   touched), and a recommendation. Lead with the recommended one.
+4. **Converge section-by-section**: present the design in pieces and get explicit
+   agreement on each — data model, API surface, failure modes, test strategy.
+5. **Write the spec**: a short markdown doc (problem, chosen design, rejected
+   alternatives + why, test plan). For substantial work, feed it straight into
+   `/write-a-prd`.
+6. **Review loop**: have a fresh subagent attack the spec ("what breaks? what's
+   missing?") before declaring it done. `/grill-me` is the heavier version.
+
+## Extend this by…
+
+Keeping reusable design templates per change-type (new endpoint, new service, new
+agent node) and starting step 3 from the matching template.

--- a/.claude/skills/cleanup-experiment/SKILL.md
+++ b/.claude/skills/cleanup-experiment/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: cleanup-experiment
+description: Retire a finished retrieval experiment — promote the winner to the default, remove variant flags/conditionals/tests, update the experiment log. Use with a slug, e.g. /cleanup-experiment rrf-k-20.
+---
+
+# Cleanup Experiment
+
+Experiments that linger become dead code. Retire them deliberately.
+
+## Steps
+
+1. **Confirm the verdict**: check the experiment's row and eval results in
+   `docs/experiments.md`. No recorded result → stop and run `/offline-eval` first.
+2. **Promote or revert**:
+   - **Variant won**: make the variant value the default (settings class in
+     `src/config.py`, or the constant in
+     `src/services/opensearch/index_config_hybrid.py`), and remove the override
+     plumbing if it was experiment-only.
+   - **Control won**: delete the variant plumbing entirely.
+3. **Sweep the residue**: grep the slug and the flag name across `src/`, `tests/`,
+   `.env*`, `compose.yml`. Remove experiment-only tests; keep (and rename) any test
+   that now guards the promoted default.
+4. **Update the log**: set status in `docs/experiments.md` to
+   `concluded — <winner> shipped`, with one line of evidence.
+5. **Ship it**: this is normal code change — go through `/work-issue` (or at minimum
+   a reviewed PR), not a direct push.
+
+## Extend this by…
+
+Auto-detecting stale experiments (active > 30 days) or batching multiple retirements
+into a single sweep PR.

--- a/.claude/skills/generate-tests/SKILL.md
+++ b/.claude/skills/generate-tests/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: generate-tests
+description: Generate pytest tests for a target file following this repo's conventions (class-based, asyncio auto mode, AsyncMock, factory patching). Use with a path, e.g. /generate-tests src/services/ollama/client.py.
+---
+
+# Generate Tests
+
+Write tests that look like they were always here.
+
+## Steps
+
+1. **Read the target** (`$ARGUMENTS`) and its existing tests, if any. Find the
+   mirroring test path: `src/services/x/y.py` → `tests/unit/services/x/test_y.py`;
+   router behavior → `tests/api/routers/test_<router>.py`.
+2. **Study a neighbor test file first** (e.g. `tests/unit/services/test_arxiv_client.py`,
+   `tests/api/routers/test_agentic_ask.py`) and copy its idioms.
+3. **Repo conventions** (non-negotiable):
+   - Class-based: `class TestSearchUnified:` grouping related cases.
+   - `asyncio_mode = "auto"` — async tests are plain `async def test_*`, no marker.
+   - Inline `@pytest.fixture` in the test file; shared API fixtures come from
+     `tests/api/conftest.py` (`LifespanManager` + `AsyncClient`).
+   - Mock with `MagicMock`/`AsyncMock`; patch service construction at the factory
+     (`src.services.<pkg>.factory.make_*`), not deep internals.
+   - Cover: happy path, one edge case per branch, error propagation.
+4. **Run them**: `uv run pytest <new test file> -q`, then `make test` for the suite.
+   Don't hand over red tests.
+
+## Extend this by…
+
+Generating property-based tests (hypothesis), coverage-gap targeting from
+`make test-cov` output, or parametrized fixtures for the OpenSearch query matrix.

--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: grill-me
+description: Relentlessly interrogate a plan, design, or PRD — walk every branch of the decision tree until nothing is hand-waved. Use before committing to a design you can't cheaply undo.
+---
+
+# Grill Me
+
+The user presents a plan; you find every unanswered question in it. You're done when
+neither side can produce a question the design doesn't already answer.
+
+## Rules
+
+1. **One question at a time.** Wait for the answer before the next.
+2. **Walk the tree**: every decision implies sub-decisions. "Cache the embeddings" →
+   where? invalidated when? what's the failure mode when Redis is down? what does the
+   cold path cost?
+3. **Attack the seams**: error paths, concurrency (two sessions, two worktrees),
+   migrations/rollbacks, the empty state, the 10x-scale state.
+4. **No vibes**: when an answer is "probably fine", make it concrete — which file,
+   which test would prove it, what's the number.
+5. **Track the ledger**: keep a running list of *resolved* vs *open* points; show it
+   on request. Finish by dumping the resolved decisions as bullet points the user can
+   paste into the spec or PRD.
+
+## Extend this by…
+
+Domain question-packs (one for retrieval changes, one for agent-graph changes, one for
+infra) seeded from past post-merge findings.

--- a/.claude/skills/list-experiments/SKILL.md
+++ b/.claude/skills/list-experiments/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: list-experiments
+description: Inventory retrieval experiments — active, concluded, and stale — by reading the experiment log and grepping the codebase for experiment flags.
+---
+
+# List Experiments
+
+One table: what's running, what's done, what's rotting.
+
+## Steps
+
+1. **Read the log**: `docs/experiments.md` (slug, knob, status, dates). Missing file
+   → report "no experiments recorded" and check step 2 anyway.
+2. **Cross-check the code**: grep `src/` and `.env*` for experiment slugs and
+   override env vars (`CHUNKING__`, `OPENSEARCH__`, experiment-named settings).
+   Flags in code but not in the log → **untracked**; log says active but no code
+   references → **ghost**.
+3. **Staleness**: anything `active` for >30 days gets flagged stale with a pointer to
+   `/cleanup-experiment`.
+4. **Report**:
+
+   | Slug | Knob | Status | Age | Action |
+   |---|---|---|---|---|
+   | rrf-k-20 | rank_constant 60→20 | active | 12d | awaiting eval |
+
+## Extend this by…
+
+Linking each row to its eval report and PRD, or failing `/local-ci` when untracked
+experiment flags are detected.

--- a/.claude/skills/local-ci/SKILL.md
+++ b/.claude/skills/local-ci/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: local-ci
+description: Run all CI checks locally and report pass/fail — the pre-merge gate. Mirrors .github/workflows/ci.yml, plus integration tests on feature branches. Read-only; never fixes or merges.
+---
+
+# Local CI
+
+Replicate the CI pipeline locally so nothing merges red. **Read-only**: report
+results, never modify code or merge.
+
+## Mode detection
+
+```bash
+branch=$(git rev-parse --abbrev-ref HEAD)
+ahead=$(git rev-list --count origin/main..HEAD 2>/dev/null || echo 0)
+# PRE_MERGE mode when on a feature branch ahead of origin/main
+```
+
+## Jobs (always — mirrors .github/workflows/ci.yml)
+
+1. **lint** — `uv run ruff check`
+2. **format** — `uv run ruff format --check`
+3. **types** — `uv run mypy src/`
+4. **unit tests (hermetic)** — `uv run pytest tests/unit --ignore=tests/unit/services/agents --cov=src`
+   (the agents exclusion matches ci.yml while Week 7 stabilizes; drop it when CI does)
+5. **compose config** — `docker compose config -q`
+
+## Pre-merge jobs (feature branches only — these need live services)
+
+6. **services up?** — `make health`; if any service is down, report and skip jobs 7-8
+   with a warning (do not start services yourself).
+7. **api tests** — `uv run pytest tests/api/` (FastAPI lifespan connects to real
+   Redis/OpenSearch)
+8. **integration tests** — `uv run pytest tests/integration/`
+
+## Flags
+
+- `--skip <job>` — skip named job(s)
+- `--only <job>` — run only named job(s)
+- `--no-pre-merge` / `--force-pre-merge` — override mode detection
+
+## Output format
+
+One line per job (✅/❌/⏭ + duration), then a summary block:
+
+```
+Local CI: PASS (5 passed, 0 failed, 2 skipped)
+```
+
+On FAIL: list the failing jobs with the last ~15 lines of each failure. Stop there —
+fixing is the caller's job.
+
+## Extend this by…
+
+Adding a coverage threshold gate, a Trivy image scan, or caching the last green commit
+to skip unchanged jobs.

--- a/.claude/skills/offline-eval/SKILL.md
+++ b/.claude/skills/offline-eval/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: offline-eval
+description: Evaluate a retrieval experiment offline — run a query set through the API for control vs variant, compute overlap/rank metrics, optionally LLM-as-judge via Ollama — and emit a comparison table.
+---
+
+# Offline Eval
+
+Compare control vs variant on real queries before anything ships. Requires services
+up (`make health` first).
+
+## Steps
+
+1. **Query set**: use `docs/eval-queries.md` if present, else generate 10-15 diverse
+   questions from indexed papers (factual, comparative, methodological) and save them
+   there for reuse.
+2. **Run both arms** against `POST /api/v1/ask` (or `POST /api/v1/search` for
+   retrieval-only evals):
+   ```bash
+   curl -s localhost:8000/api/v1/ask -H 'content-type: application/json' \
+     -d '{"query": "<q>", "top_k": 5, "use_hybrid": true}'
+   ```
+   Control = current defaults; variant = the env overrides printed by
+   `/setup-experiment` (restart the API with them: `make restart`).
+3. **Retrieval metrics** per query, from the `sources`/chunks returned:
+   - **hit overlap** (Jaccard of retrieved chunk ids)
+   - **rank shifts** of shared hits
+   - score deltas where available
+4. **LLM-as-judge (optional)**: for answer-level evals, ask the local model to grade
+   both answers blind (A/B order randomized) on relevance + groundedness, 1-5:
+   `OllamaClient.generate()` (`src/services/ollama/client.py`) or a direct
+   `curl localhost:11434/api/generate`. Judge model ≠ generation model where possible.
+5. **Report**: per-query table + aggregate (mean overlap, judge win-rate), a 3-line
+   interpretation, and a recommendation: *ship variant / keep control / needs more
+   queries*. Update the experiment's row in `docs/experiments.md`.
+
+## Extend this by…
+
+nDCG against a labeled relevance set, statistical significance on win-rates, or
+batch-running the query set through the Airflow DAG.

--- a/.claude/skills/setup-experiment/SKILL.md
+++ b/.claude/skills/setup-experiment/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: setup-experiment
+description: Scaffold a retrieval experiment — a variant behind a config flag with boilerplate tests — for knobs like RRF rank_constant, chunk_size, or BM25-vs-hybrid. Use when starting an A/B retrieval comparison.
+---
+
+# Setup Experiment
+
+Scaffold a control-vs-variant retrieval experiment behind a config flag, so
+`/offline-eval` can compare them and `/cleanup-experiment` can retire the loser.
+
+## Real knobs in this repo
+
+| Knob | Where | Default |
+|---|---|---|
+| RRF `rank_constant` | `src/services/opensearch/index_config_hybrid.py` (`HYBRID_RRF_PIPELINE`) | 60 |
+| `chunk_size` / `overlap_size` | `ChunkingSettings` in `src/config.py` (env: `CHUNKING__CHUNK_SIZE`) | 600 / 100 |
+| BM25 vs hybrid | `use_hybrid` on `AskRequest` → `OpenSearchClient.search_unified()` | hybrid |
+| Retrieval depth | `top_k` on `AskRequest` (1-10) | 3 |
+
+## Steps
+
+1. **Name the experiment**: short slug, e.g. `rrf-k-20`. One hypothesis per
+   experiment ("lower rank_constant favors top-ranked lexical hits → better precision").
+2. **Wire the variant behind config, not code forks**:
+   - Settings-based knobs need no code change — document the env override
+     (e.g. `CHUNKING__CHUNK_SIZE=300`).
+   - For knobs that are currently constants (e.g. `rank_constant`), lift the constant
+     into the relevant settings class in `src/config.py` with the current value as
+     default, and thread it through (e.g. into `HYBRID_RRF_PIPELINE` construction).
+3. **Add boilerplate tests**: a unit test asserting the default is unchanged, and one
+   asserting the override reaches the OpenSearch request body
+   (`tests/unit/services/test_opensearch_query_builder.py` shows the idiom).
+4. **Record the experiment**: add a row to `docs/experiments.md` (create if missing):
+   slug · knob · control · variant · hypothesis · status `active`.
+5. **Hand off**: print the exact env overrides for control and variant runs, ready for
+   `/offline-eval`.
+
+## Extend this by…
+
+Multi-arm variants, per-request experiment headers, or persisting experiment metadata
+in Postgres instead of a markdown table.

--- a/.claude/skills/work-issue/SKILL.md
+++ b/.claude/skills/work-issue/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: work-issue
+description: Ship a GitHub issue end-to-end — worktree, test-first implementation, review, PR, local CI, merge, PRD update. Use with an issue number, e.g. /work-issue 42.
+---
+
+# Work an Issue
+
+Take a GitHub issue from open to merged without touching the primary checkout.
+
+## Steps
+
+1. **Read the issue**: `gh issue view $1 --comments`. Require ≥2 acceptance-criteria
+   bullets and a test plan — stop and ask if missing. Note the parent PRD number
+   ("Part of #N") if present. Block on open upstream dependencies.
+2. **Sync + worktree** (mandatory — the primary checkout stays on `main`):
+   ```bash
+   git fetch origin main
+   git worktree add .claude/worktrees/issue-$1 origin/main
+   cd .claude/worktrees/issue-$1
+   git checkout -b feat/$1-<slug>     # or fix/ chore/ docs/
+   ```
+3. **Implement test-first**: regression test in the same commit as the change. The
+   PostToolUse hook runs pre-commit on every edit — treat failures as blockers.
+   Follow `CLAUDE.md` conventions (factories, class-based tests, `AsyncMock`).
+4. **Review**: run `/code-review` on the diff. Apply in-scope fixes only; defer
+   out-of-scope refactors to new issues.
+5. **Size check**: if the diff exceeds **500 lines or 10 files**, or touches risky
+   paths (`compose.yml`, `Dockerfile`, `.github/`, `.env*`, `airflow/`), label the PR
+   `needs-human-review` and do not auto-merge.
+6. **Open the PR**: stage specific files (`git add <paths>`, never `-A`), push, then:
+   ```bash
+   gh pr create --title "<title>" --body "Closes #$1
+
+   ## Summary
+   - <bullets>
+
+   ## Test plan
+   - [ ] <from the issue>"
+   ```
+   `Closes #$1` is mandatory so the issue auto-closes on merge.
+7. **Update the parent PRD** (if any): comment the PR URL and set the Linked-work
+   table row to "Open" (`gh issue edit <prd> --body-file -`).
+8. **Run `/local-ci`** — the pre-merge gate. FAIL → fix and re-run; do not merge red.
+9. **Merge if safe** (within size limits, no risky paths, local-ci green), from
+   outside the worktree:
+   ```bash
+   cd /tmp && gh pr merge <num> --squash --delete-branch
+   ```
+   Never `gh pr merge --auto`. Large/risky PRs: print the URL and stop for a human.
+10. **Close the loop**: set the PRD row to "Merged"; if this PR fixed something a
+    previous PR missed, append 2-4 lines to the PRD's "Post-merge findings".
+    Remove the worktree (`git worktree remove .claude/worktrees/issue-$1`) and verify
+    the primary checkout is still clean on `main`.
+
+## Extend this by…
+
+Auto-assigning reviewers, posting a summary to the team channel, or chaining the next
+issue from the PRD's parallel-safe set.

--- a/.claude/skills/write-a-prd/SKILL.md
+++ b/.claude/skills/write-a-prd/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: write-a-prd
+description: Create a PRD as a living GitHub issue — dependency graph, per-issue test plans, Linked-work table — then create the child implementation issues. Use when starting any substantial feature.
+---
+
+# Write a PRD
+
+Create a PRD that lives as a GitHub issue and acts as the hub for all implementation
+work. Child issues are the spokes; the Linked-work table tracks them to merge.
+
+## Steps
+
+1. **Sync first**: `git fetch origin main`. PRDs written against stale code create
+   collisions later.
+2. **Interview the user**: problem statement, current behavior (with `file:line`
+   references you have verified), user-facing impact. Don't accept vague assertions —
+   open the files and confirm.
+3. **Explore the repo**: find existing patterns to reuse (service factories `make_*()`,
+   router/service/repository layering, schema conventions in `src/schemas/`). The PRD
+   should name modules, not invent new architecture where one exists.
+4. **Build the dependency graph**: list implementation issues, draw the tree, and
+   identify the **parallel-safe set** (issues with no shared files that can be worked
+   concurrently in separate worktrees).
+5. **Write a test plan per issue** — specific assertions, not "add tests".
+   Example: "ask endpoint with `use_hybrid=false` → `search_unified()` called with
+   BM25-only path → response `sources` non-empty".
+6. **Default: one PR per issue.** If the user wants to bundle, document the override
+   in "Further notes".
+7. **Create the PRD issue**:
+   ```bash
+   gh issue create --title "PRD: <feature>" --body-file <prd.md>
+   ```
+   Mandatory sections: Problem Statement · Solution · Implementation Decisions
+   (module names, no file paths) · Dependency graph + parallel-safe set ·
+   Implementation issues (title, depends-on, test plan, files touched) ·
+   Out of Scope · **Linked work** table (empty at creation) ·
+   **Post-merge findings** (empty at creation).
+8. **Create child issues**, one per implementation item, each with body
+   "Part of #<PRD-number>" plus its test plan.
+9. **Update the PRD**: fill the Linked-work table with the child issue numbers,
+   status "Not started". Print the PRD URL.
+
+## Linked-work table format
+
+| Issue | PR | Status |
+|---|---|---|
+| #N | — | Not started / Open / Merged |
+
+`/work-issue` updates this table as PRs open and merge, and appends to Post-merge
+findings when follow-up fixes reveal process gaps.
+
+## Extend this by…
+
+Adding effort estimates per issue, a rollback plan section, or auto-labeling child
+issues (`gh issue edit --add-label`).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Lint
+        run: uv run ruff check
+
+      - name: Format check
+        run: uv run ruff format --check
+
+      - name: Type check
+        run: uv run mypy src/
+
+      # Hermetic unit tests only. tests/api and tests/integration need live services
+      # (make start) — run them locally via /local-ci. tests/unit/services/agents is
+      # excluded while the Week 7 agentic RAG work is being stabilized; re-enable after.
+      - name: Unit tests
+        run: uv run pytest tests/unit --ignore=tests/unit/services/agents

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           python-version: "3.12"
 

--- a/.gitignore
+++ b/.gitignore
@@ -136,8 +136,10 @@ cython_debug/
 claude_session_*
 .claude_session/
 *.claude_session
-.claude/
-CLAUDE.md
+# Personal Claude Code files (committed: .claude/settings.json, skills/, commands/, CLAUDE.md)
+.claude/settings.local.json
+.claude/worktrees/
+.claude/docs/
 
 # PyCharm
 .idea/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,113 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repository.
+
+## Project Overview
+
+**moai-zero-to-rag** — The Mother of AI, Phase 1: arXiv Paper Curator. A 7-week,
+production-grade RAG curriculum: FastAPI → OpenSearch hybrid search → Ollama RAG →
+LangGraph agentic RAG → Telegram bot. Each week's architecture and learning material
+lives in `README.md` (weekly table) and `notebooks/week1/` … `notebooks/week7/`.
+
+## Common Commands
+
+All services run via Docker Compose; Python tooling runs through `uv` (never pip).
+
+```bash
+make start      # docker compose up --build -d (API, Postgres, OpenSearch, Airflow, Ollama, Redis, Langfuse)
+make stop       # docker compose down
+make status     # docker compose ps
+make logs       # docker compose logs -f
+make health     # curl checks: API :8000, OpenSearch :9200, Airflow :8080, Ollama :11434
+make setup      # uv sync
+make format     # uv run ruff format
+make lint       # uv run ruff check --fix && uv run mypy src/
+make test       # uv run pytest
+make test-cov   # uv run pytest --cov=src --cov-report=html
+make clean      # docker compose down -v && docker system prune -f
+```
+
+## Architecture Map
+
+Request flow: `src/routers/` → `src/services/` → `src/repositories/` (Postgres) /
+OpenSearch.
+
+- **Routers** (`src/routers/`): `ask.py` (`POST /api/v1/ask`, classic RAG),
+  `hybrid_search.py` (`POST /api/v1/search`), `agentic_ask.py`
+  (`POST /api/v1/ask-agentic`, LangGraph), `ping.py`.
+- **OpenSearch** (`src/services/opensearch/`): `client.py` — `search_unified()` routes
+  BM25-only vs hybrid via the `use_hybrid` flag; `query_builder.py` builds queries;
+  `index_config_hybrid.py` defines the index and the RRF pipeline
+  (`HYBRID_RRF_PIPELINE`, `rank_constant=60`).
+- **Agentic RAG** (`src/services/agents/`): LangGraph workflow in `agentic_rag.py`,
+  nodes under `nodes/`, state in `state.py`, prompts in `prompts.py`.
+- **LLM** (`src/services/ollama/`): `client.py` — `generate()`, `generate_stream()`,
+  `generate_rag_answer()`. Local models via Ollama (default `llama3.2:1b`).
+- **Other services**: `arxiv/` (API client), `pdf_parser/` (Docling), `indexing/`
+  (chunking), `embeddings/` (Jina, 1024-dim), `cache/` (Redis), `langfuse/` (tracing),
+  `telegram/` (bot), `metadata_fetcher.py` (ingestion orchestrator).
+- **Config** (`src/config.py`): nested pydantic-settings; access via `get_settings()`.
+  Env vars use `__` nesting (e.g. `OPENSEARCH__HOST`, `CHUNKING__CHUNK_SIZE`,
+  `ARXIV__MAX_RESULTS`).
+- **Pipelines**: Airflow DAGs in `airflow/dags/`.
+- **Schemas** (`src/schemas/`): Pydantic models; API request/response under
+  `schemas/api/` (e.g. `AskRequest` with `top_k`, `use_hybrid`, `model`).
+
+Services are constructed through `make_*()` factory functions (`factory.py` in each
+service package) — use these, don't instantiate clients directly.
+
+## Conventions
+
+- **Python 3.12**, dependencies managed by `uv` (`pyproject.toml` + `uv.lock`).
+- **Ruff**: import sorting only (`lint.select = ["I"]`) + formatting, line length 130.
+  Don't introduce other lint rules in code changes.
+- **Mypy**: configured lenient (`ignore_errors = true`); still keep annotations on new
+  public functions.
+- **Pytest**: `asyncio_mode = "auto"` (async tests need no marker), env from
+  `.env.test`. Tests are class-based (`class TestX:`), fixtures inline with
+  `@pytest.fixture`, mocking via `MagicMock`/`AsyncMock` + `pytest-mock`.
+- **Test layout**: `tests/unit/` (hermetic, mocked deps — this is what CI runs),
+  `tests/api/` (FastAPI via `LifespanManager` + `AsyncClient`, fixtures in
+  `tests/api/conftest.py`; the lifespan connects to real Redis/OpenSearch, so these
+  **need `make start`**), `tests/integration/` (hits real services). `/local-ci` runs
+  the service-dependent suites in pre-merge mode.
+- **Docstrings**: prose-first and minimal — one sentence, present tense, period.
+  Add a short WHY paragraph only when non-obvious. No section-header docstring styles.
+
+## Quality Gates
+
+- A PostToolUse hook runs `pre-commit` (ruff import-sort, ruff-format, mypy) on every
+  file you edit — treat any failure as a blocker before continuing.
+- `/local-ci` is the pre-merge gate: it replicates `.github/workflows/ci.yml` locally
+  and adds integration tests on feature branches. Run it before any merge.
+- Run a code review pass (e.g. `/code-review`) before opening a PR.
+
+## Workflow Policy
+
+- **PRD as hub**: substantial features start with `/write-a-prd` — a PRD GitHub issue
+  with a dependency graph, per-issue test plans, and a Linked-work table that tracks
+  child issues/PRs through their lifecycle. Implementation happens via `/work-issue`.
+- **One PR per issue** by default; bundling needs explicit agreement, documented in the PRD.
+- **Worktrees**: do feature work in `git worktree` checkouts under `.claude/worktrees/`,
+  never on the primary checkout. The primary working directory stays on `main` with a
+  clean tree so concurrent sessions don't collide.
+- **Test-first**: write the regression test in the same commit as the change. No test
+  plan on the issue → don't start coding.
+- **PR size limits**: ≤500 changed lines and ≤10 files for auto-merge eligibility.
+  Larger PRs need human review.
+- **Risky paths** (never auto-merge, flag for human review): `compose.yml`,
+  `Dockerfile`, `.github/`, `.env*`, `airflow/`.
+- **Merging**: squash-merge with `gh pr merge <num> --squash --delete-branch`, run from
+  outside the worktree. **Never** use `gh pr merge --auto`.
+- **Branch naming**: `feat/<desc>`, `fix/<desc>`, `chore/<desc>`, `docs/<desc>`.
+- Leave unrelated uncommitted changes in the working tree untouched; stage specific
+  files (`git add <paths>`), never `git add -A`.
+
+## Experiments
+
+Retrieval experiments toggle real knobs behind config/env flags (see
+`/setup-experiment`): RRF `rank_constant` (`index_config_hybrid.py`), `chunk_size`
+(`ChunkingSettings`), BM25-vs-hybrid (`use_hybrid` through `search_unified()`).
+Evaluate variants with `/offline-eval` (control vs variant through `POST /api/v1/ask`,
+optional LLM-as-judge via Ollama); retire finished ones with `/cleanup-experiment`;
+inventory with `/list-experiments`.

--- a/docs/workshop/claude-code-workshop.md
+++ b/docs/workshop/claude-code-workshop.md
@@ -1,0 +1,150 @@
+# Claude Code Workshop — 2 Hours, Basic → Advanced
+
+**Audience:** mid-to-senior agentic ML engineers.
+**Format:** live demo on this repo. Attendees watch, ask, and leave with a repo they
+can clone — every artifact demoed is committed here.
+**Thesis:** Claude Code isn't a chat box, it's a programmable engineering harness.
+This repo's `.claude/` directory is the syllabus.
+
+---
+
+## Prep checklist (do this the day before AND 30 min before)
+
+- [ ] `make start` then `make health` — API :8000, OpenSearch :9200, Airflow :8080,
+      Ollama :11434 all green. A few papers ingested and indexed (Week 2 DAG run).
+- [ ] `gh auth status` green; push access to the repo.
+- [ ] `uv run pre-commit run --all-files` passes (so the hook demo fails only when
+      you *want* it to).
+- [ ] Pre-stage a small demo issue (used in the centerpiece): e.g. "Add a `sources`
+      count field to AskResponse" with acceptance criteria + test plan.
+- [ ] Terminal font ≥16pt; `claude` starts clean in the repo root.
+- [ ] Fallback (see bottom) rehearsed once end-to-end this week.
+
+---
+
+## Run of show
+
+### 0:00–0:15 — Foundations: the harness, not the chat box
+
+| Show | How |
+|---|---|
+| CLAUDE.md anatomy | Open `CLAUDE.md`; explain it loads every session: commands, architecture map, conventions, policy. Contrast with prompting from scratch. |
+| `/init` story | Mention: this file was *generated then curated* — `/init` bootstraps it on any repo. |
+| Context economics | `/context` (what's loaded, token costs), `/compact` (summarize to keep going). |
+| Permission modes | `/permissions`; default vs `acceptEdits` vs plan mode. Plan mode live: ask for a refactor, show it explores read-only and proposes before touching anything. |
+| Memory | Ask Claude to remember a preference; show it persists across sessions. |
+
+**Beat to land:** "Everything else in the next 105 minutes is configuration *of this harness*, checked into git like any other code."
+
+### 0:15–0:35 — Skills vs commands: teach the distinction with files
+
+| Show | How |
+|---|---|
+| Legacy command | Open `.claude/commands/create-pr.md` — a prompt in a file, `$ARGUMENTS` substitution, user-invoked only. Run `/daily-standup` live (30s payoff). |
+| Skill | Open `.claude/skills/generate-tests/SKILL.md` — frontmatter (`name`, `description`), the description is what lets Claude *auto-invoke* it when relevant. |
+| The contrast | Commands = user-triggered prompt expansion. Skills = model-discoverable capabilities with structure, supporting files, invocation control. |
+| Live run | `/generate-tests src/services/ollama/client.py` — watch it study neighbor tests first (that instruction is *in the skill*), then write conventional tests. |
+| Anatomy tour | `ls -R .claude/` — settings, skills, commands, worktrees convention. 60 seconds, just the shape. |
+
+### 0:35–0:55 — Hooks, settings, permissions: determinism around the model
+
+| Show | How |
+|---|---|
+| The hook | Open `.claude/settings.json` → PostToolUse runs pre-commit on every edited file. |
+| Fire it live | Ask Claude to add an import in the wrong order somewhere; the hook auto-fixes/flags **immediately** — no "please run the linter" prompting. |
+| Why it matters | Hooks are *enforced by the harness*, not the model's goodwill. CLAUDE.md is advice; hooks are law. |
+| Permissions | Walk the allowlist in `settings.json`: pre-approved `make`/`uv`/`gh` reads vs everything else prompting. `settings.local.json` for personal overrides (gitignored). |
+| Mention | Sandboxed bash, PreToolUse blocking hooks (exit 2), managed org settings — pointers for the security-minded. |
+
+### 0:55–1:20 — Centerpiece: the engineering workflow
+
+The full loop, live, on the pre-staged demo issue:
+
+1. `/write-a-prd` (abbreviated — show the PRD issue structure it produces: dependency
+   graph, per-issue test plans, **Linked-work table**, Post-merge findings).
+2. `/work-issue <N>` — narrate as it goes:
+   - worktree under `.claude/worktrees/issue-N` (primary checkout never leaves main —
+     this is how you run 3 sessions in parallel without collisions)
+   - test-first edit; hook fires on every write
+   - `/code-review` pass before the PR
+   - PR opens with `Closes #N`; PRD table flips to "Open"
+3. `/local-ci` — the pre-merge gate; jobs mirror `.github/workflows/ci.yml` exactly,
+   plus integration tests because we're on a feature branch.
+4. Squash-merge from outside the worktree; PRD table flips to "Merged"; worktree removed.
+
+**Beat to land:** the PRD is a *living hub* — six weeks later you can read it and know
+what shipped, what broke, and what the team learned (Post-merge findings).
+
+### 1:20–1:40 — Agentic ML workflows: experiments as a first-class loop
+
+1. `/setup-experiment` — scaffold `rrf-k-20`: lift `rank_constant` (see
+   `src/services/opensearch/index_config_hybrid.py`) into config, variant behind an
+   env override, boilerplate tests, logged in `docs/experiments.md`.
+2. `/offline-eval` — control vs variant through `POST /api/v1/ask`; hit-overlap +
+   rank-shift table; **LLM-as-judge with local Ollama** (blind A/B, randomized order).
+3. `/cleanup-experiment` + `/list-experiments` — experiments get *retired*, not
+   abandoned; stale-flag detection.
+4. While the eval runs: **subagents** — fire two parallel Explore agents ("map the
+   chunking pipeline" / "map the agent graph") and show both come back while the main
+   context stays clean. Mention background tasks (`/tasks`).
+
+**Beat to land:** the same skill pattern that automates PRs automates *your ML
+iteration loop* — eval harnesses, judge prompts, experiment hygiene.
+
+### 1:40–1:55 — Advanced & scale (concepts + pointers, no deep demo)
+
+- **Plugins & marketplaces**: bundle skills+hooks+MCP into installable packages;
+  official + community marketplaces; this repo's `.claude/` could ship as one.
+- **MCP**: connect external systems (GitHub, observability, DBs) as tools; `.mcp.json`.
+- **Claude in CI**: the Claude Code GitHub Action — automated PR review/fix loops in
+  Actions (concept; we deliberately ship plain `ci.yml` here).
+- **Agent SDK**: the same loop, headless, in Python/TypeScript — build your own
+  agents on the harness that just ran your PR.
+- **Agent Teams** (experimental): multiple coordinated sessions with a shared task
+  list — the worktree convention you saw is what makes this safe.
+- **Checkpoints & rewind**: `/rewind` after a bad path; resume sessions.
+
+### 1:55–2:00 — Q&A + adoption checklist
+
+What to copy into your repo **tomorrow**, in order of ROI:
+1. `CLAUDE.md` (run `/init`, then curate to ~150 lines)
+2. The PostToolUse lint/type hook (10 lines of JSON, immediate payoff)
+3. A `/local-ci` skill mirroring your CI
+4. One workflow skill you repeat weekly (PR creation, test generation)
+5. The PRD/work-issue loop once the team trusts 1–4
+
+---
+
+## Fallback plan
+
+If the live GitHub flow stalls (network, gh auth, Actions queue):
+- A throwaway branch with the completed centerpiece artifacts (PRD issue screenshot,
+  merged PR) prepared the day before — narrate from those.
+- Every skill also runs read-only: `/local-ci --only lint,types` and
+  `/list-experiments` need no network.
+- Worst case: open the SKILL.md files and teach from the artifacts — they're written
+  to be read.
+
+---
+
+## Appendix: Claude Code feature inventory (cheat sheet)
+
+| Feature | What it is | Level |
+|---|---|---|
+| CLAUDE.md | Per-repo instructions loaded every session | Basic |
+| Memory | Persistent cross-session facts Claude maintains | Basic |
+| Slash commands (built-in) | `/init`, `/context`, `/compact`, `/permissions`, `/rewind`, `/agents`, … | Basic |
+| Custom commands | Prompt-in-a-file, `$ARGUMENTS` (`.claude/commands/`) | Basic |
+| Skills | Model-discoverable capabilities with frontmatter (`.claude/skills/*/SKILL.md`) | Intermediate |
+| Settings & permissions | allow/ask/deny rules, permission modes, `settings.local.json` | Intermediate |
+| Hooks | Deterministic shell hooks at lifecycle events (PostToolUse, PreToolUse, …) | Intermediate |
+| Plan mode | Read-only explore → approved plan → execute | Intermediate |
+| Subagents | Parallel workers with isolated context | Intermediate |
+| Worktrees | Parallel sessions without checkout collisions | Intermediate |
+| Background tasks | Long-running work that doesn't block the session | Intermediate |
+| MCP | External tools/services via Model Context Protocol | Intermediate |
+| Plugins & marketplaces | Distributable bundles of skills/hooks/MCP | Advanced |
+| GitHub Action | Claude review/fix loops inside CI | Advanced |
+| Agent SDK | Headless harness in Python/TS for custom agents | Advanced |
+| Agent Teams | Coordinated multi-session swarms (experimental) | Advanced |
+| Sandboxing & managed settings | OS-level bash isolation; org-enforced policy | Advanced |

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -13,6 +13,8 @@ else:
 
 from src.config import Settings
 from src.db.interfaces.base import BaseDatabase
+from src.services.agents.agentic_rag import AgenticRAGService
+from src.services.agents.factory import make_agentic_rag_service
 from src.services.arxiv.client import ArxivClient
 from src.services.cache.client import CacheClient
 from src.services.embeddings.jina_client import JinaEmbeddingsClient
@@ -21,8 +23,6 @@ from src.services.ollama.client import OllamaClient
 from src.services.opensearch.client import OpenSearchClient
 from src.services.pdf_parser.parser import PDFParserService
 from src.services.telegram.bot import TelegramBot
-from src.services.agents.agentic_rag import AgenticRAGService
-from src.services.agents.factory import make_agentic_rag_service
 
 
 @lru_cache

--- a/src/routers/agentic_ask.py
+++ b/src/routers/agentic_ask.py
@@ -81,10 +81,7 @@ async def submit_feedback(
     """
     try:
         if not langfuse_tracer:
-            raise HTTPException(
-                status_code=503,
-                detail="Langfuse tracing is disabled. Cannot submit feedback."
-            )
+            raise HTTPException(status_code=503, detail="Langfuse tracing is disabled. Cannot submit feedback.")
 
         success = langfuse_tracer.submit_feedback(
             trace_id=request.trace_id,
@@ -96,20 +93,11 @@ async def submit_feedback(
             # Flush to ensure feedback is sent immediately
             langfuse_tracer.flush()
 
-            return FeedbackResponse(
-                success=True,
-                message="Feedback recorded successfully"
-            )
+            return FeedbackResponse(success=True, message="Feedback recorded successfully")
         else:
-            raise HTTPException(
-                status_code=500,
-                detail="Failed to submit feedback to Langfuse"
-            )
+            raise HTTPException(status_code=500, detail="Failed to submit feedback to Langfuse")
 
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=500,
-            detail=f"Error submitting feedback: {str(e)}"
-        )
+        raise HTTPException(status_code=500, detail=f"Error submitting feedback: {str(e)}")

--- a/src/services/agents/agentic_rag.py
+++ b/src/services/agents/agentic_rag.py
@@ -6,7 +6,6 @@ from langchain_core.messages import HumanMessage
 from langfuse.langchain import CallbackHandler
 from langgraph.graph import END, START, StateGraph
 from langgraph.prebuilt import ToolNode, tools_condition
-
 from src.services.embeddings.jina_client import JinaEmbeddingsClient
 from src.services.langfuse.client import LangfuseTracer
 from src.services.ollama.client import OllamaClient
@@ -30,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 class AgenticRAGService:
-    """Agentic RAG service 
+    """Agentic RAG service
 
     This implementation uses:
     - context_schema for dependency injection
@@ -410,8 +409,7 @@ class AgenticRAGService:
             logger.error(f"Failed to generate visualization - missing dependencies: {e}")
             logger.error("Install with: pip install pygraphviz or apt-get install graphviz")
             raise ImportError(
-                "Graph visualization requires pygraphviz. "
-                "Install with: pip install pygraphviz (requires graphviz system package)"
+                "Graph visualization requires pygraphviz. Install with: pip install pygraphviz (requires graphviz system package)"
             ) from e
         except Exception as e:
             logger.error(f"Failed to generate graph visualization: {e}")

--- a/src/services/agents/config.py
+++ b/src/services/agents/config.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict
 
 from pydantic import BaseModel, Field
-
 from src.config import Settings, get_settings
 
 

--- a/src/services/agents/context.py
+++ b/src/services/agents/context.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
-from langfuse._client.span import LangfuseSpan
 from typing import TYPE_CHECKING, Optional
 
+from langfuse._client.span import LangfuseSpan
 from src.services.embeddings.jina_client import JinaEmbeddingsClient
 from src.services.langfuse.client import LangfuseTracer
 from src.services.ollama.client import OllamaClient

--- a/src/services/agents/models.py
+++ b/src/services/agents/models.py
@@ -74,9 +74,7 @@ class RoutingDecision(BaseModel):
     :param reason: Explanation for the routing decision
     """
 
-    route: Literal["retrieve", "out_of_scope", "generate_answer", "rewrite_query"] = Field(
-        description="Next node to route to"
-    )
+    route: Literal["retrieve", "out_of_scope", "generate_answer", "rewrite_query"] = Field(description="Next node to route to")
     reason: str = Field(default="", description="Reason for routing decision")
 
 

--- a/src/services/agents/nodes/generate_answer_node.py
+++ b/src/services/agents/nodes/generate_answer_node.py
@@ -90,7 +90,7 @@ async def ainvoke_generate_answer_step(
         response = await llm.ainvoke(answer_prompt)
 
         # Extract content from response
-        answer = response.content if hasattr(response, 'content') else str(response)
+        answer = response.content if hasattr(response, "content") else str(response)
         logger.info(f"Generated answer of length: {len(answer)} characters")
 
         # Update span with successful result

--- a/src/services/agents/nodes/guardrail_node.py
+++ b/src/services/agents/nodes/guardrail_node.py
@@ -115,10 +115,7 @@ async def ainvoke_guardrail_step(
         logger.error(f"LLM guardrail validation failed: {e}, falling back to default")
 
         # Fallback to a conservative default if LLM fails
-        response = GuardrailScoring(
-            score=50,
-            reason=f"LLM validation failed, using conservative default: {str(e)}"
-        )
+        response = GuardrailScoring(score=50, reason=f"LLM validation failed, using conservative default: {str(e)}")
 
         # Update span with error
         if span:

--- a/src/services/agents/nodes/rewrite_query_node.py
+++ b/src/services/agents/nodes/rewrite_query_node.py
@@ -16,12 +16,8 @@ logger = logging.getLogger(__name__)
 class QueryRewriteOutput(BaseModel):
     """Structured output for query rewriting."""
 
-    rewritten_query: str = Field(
-        description="The improved query optimized for document retrieval"
-    )
-    reasoning: str = Field(
-        description="Brief explanation of how the query was improved"
-    )
+    rewritten_query: str = Field(description="The improved query optimized for document retrieval")
+    reasoning: str = Field(description="Brief explanation of how the query was improved")
 
 
 async def ainvoke_rewrite_query_step(
@@ -96,10 +92,7 @@ async def ainvoke_rewrite_query_step(
         reasoning = result.reasoning
 
         llm_duration = time.time() - llm_start
-        logger.info(
-            f"Query rewritten in {llm_duration:.2f}s: "
-            f"'{original_question[:50]}...' -> '{rewritten_query[:50]}...'"
-        )
+        logger.info(f"Query rewritten in {llm_duration:.2f}s: '{original_question[:50]}...' -> '{rewritten_query[:50]}...'")
         logger.debug(f"Rewriting reasoning: {reasoning}")
 
     except Exception as e:
@@ -123,7 +116,7 @@ async def ainvoke_rewrite_query_step(
                 "execution_time_ms": execution_time,
                 "original_length": len(original_question),
                 "rewritten_length": len(rewritten_query),
-                "llm_duration_seconds": llm_duration if 'llm_duration' in locals() else None,
+                "llm_duration_seconds": llm_duration if "llm_duration" in locals() else None,
             },
         )
 

--- a/src/services/agents/tools.py
+++ b/src/services/agents/tools.py
@@ -2,7 +2,6 @@ import logging
 
 from langchain_core.documents import Document
 from langchain_core.tools import tool
-
 from src.services.embeddings.jina_client import JinaEmbeddingsClient
 from src.services.opensearch.client import OpenSearchClient
 

--- a/src/services/ollama/client.py
+++ b/src/services/ollama/client.py
@@ -116,9 +116,8 @@ class OllamaClient:
 
                     # Calculate total tokens
                     if usage_metadata:
-                        usage_metadata["total_tokens"] = (
-                            usage_metadata.get("prompt_tokens", 0) +
-                            usage_metadata.get("completion_tokens", 0)
+                        usage_metadata["total_tokens"] = usage_metadata.get("prompt_tokens", 0) + usage_metadata.get(
+                            "completion_tokens", 0
                         )
 
                     # Parse timing information (convert nanoseconds to milliseconds)

--- a/src/services/pdf_parser/parser.py
+++ b/src/services/pdf_parser/parser.py
@@ -30,7 +30,7 @@ class PDFParserService:
             raise PDFValidationError(f"PDF file not found: {pdf_path}")
 
         try:
-            result = await self.docling_parser.parse_pdf(pdf_path)
+            result = self.docling_parser.parse_pdf(pdf_path)
             if result:
                 logger.info(f"Parsed {pdf_path.name}")
                 return result

--- a/src/services/telegram/bot.py
+++ b/src/services/telegram/bot.py
@@ -1,11 +1,10 @@
 import logging
 from typing import Optional
 
-from telegram import Update
-from telegram.ext import Application, CommandHandler, MessageHandler, filters, ContextTypes
-
 from src.schemas.api.ask import AskRequest, AskResponse
 from src.schemas.api.search import HybridSearchRequest
+from telegram import Update
+from telegram.ext import Application, CommandHandler, ContextTypes, MessageHandler, filters
 
 logger = logging.getLogger(__name__)
 
@@ -192,9 +191,7 @@ class TelegramBot:
             answer = ollama_response.get("response", "") if ollama_response else ""
 
             # Build response
-            response = AskResponse(
-                query=query, answer=answer, sources=sources, chunks_used=len(chunks), search_mode="hybrid"
-            )
+            response = AskResponse(query=query, answer=answer, sources=sources, chunks_used=len(chunks), search_mode="hybrid")
 
             # Cache it
             if self.cache:

--- a/tests/api/routers/test_agentic_ask.py
+++ b/tests/api/routers/test_agentic_ask.py
@@ -1,34 +1,37 @@
-import pytest
-from fastapi.testclient import TestClient
 from unittest.mock import AsyncMock, Mock
 
+import pytest
+from fastapi.testclient import TestClient
+from src import dependencies
 from src.main import app
 from src.services.agents.agentic_rag import AgenticRAGService
-from src import dependencies
 
 
 @pytest.fixture
 def mock_agentic_rag_service():
     """Mock AgenticRAGService for API testing."""
     service = Mock(spec=AgenticRAGService)
-    service.ask = AsyncMock(return_value={
-        "query": "What is machine learning?",
-        "answer": "Machine learning is a subset of AI that enables systems to learn from data.",
-        "sources": ["https://arxiv.org/pdf/2301.00001.pdf"],
-        "reasoning_steps": [
-            "Validated query is about AI research",
-            "Retrieved 3 relevant papers",
-            "Generated answer from sources"
-        ],
-        "retrieval_attempts": 1,
-        "rewritten_query": None,
-    })
+    service.ask = AsyncMock(
+        return_value={
+            "query": "What is machine learning?",
+            "answer": "Machine learning is a subset of AI that enables systems to learn from data.",
+            "sources": ["https://arxiv.org/pdf/2301.00001.pdf"],
+            "reasoning_steps": [
+                "Validated query is about AI research",
+                "Retrieved 3 relevant papers",
+                "Generated answer from sources",
+            ],
+            "retrieval_attempts": 1,
+            "rewritten_query": None,
+        }
+    )
     return service
 
 
 @pytest.fixture
 def client(mock_agentic_rag_service):
     """FastAPI test client with mocked dependencies."""
+
     # Override the dependency to return our mock service
     def override_get_agentic_rag_service():
         return mock_agentic_rag_service
@@ -48,12 +51,7 @@ class TestAgenticAskEndpoint:
         """Test successful agentic RAG request."""
         response = client.post(
             "/api/v1/ask-agentic",
-            json={
-                "query": "What is machine learning?",
-                "model": "llama3.2:1b",
-                "top_k": 3,
-                "use_hybrid": True
-            }
+            json={"query": "What is machine learning?", "model": "llama3.2:1b", "top_k": 3, "use_hybrid": True},
         )
 
         assert response.status_code == 200
@@ -77,10 +75,7 @@ class TestAgenticAskEndpoint:
 
     def test_ask_agentic_minimal_request(self, client, mock_agentic_rag_service):
         """Test agentic RAG with minimal required fields."""
-        response = client.post(
-            "/api/v1/ask-agentic",
-            json={"query": "What is neural network?"}
-        )
+        response = client.post("/api/v1/ask-agentic", json={"query": "What is neural network?"})
 
         assert response.status_code == 200
         data = response.json()
@@ -90,19 +85,13 @@ class TestAgenticAskEndpoint:
         """Test agentic RAG with empty query returns 422."""
         mock_agentic_rag_service.ask = AsyncMock(side_effect=ValueError("Query cannot be empty"))
 
-        response = client.post(
-            "/api/v1/ask-agentic",
-            json={"query": ""}
-        )
+        response = client.post("/api/v1/ask-agentic", json={"query": ""})
 
         assert response.status_code == 422
 
     def test_ask_agentic_missing_query(self, client):
         """Test agentic RAG without query field returns 422."""
-        response = client.post(
-            "/api/v1/ask-agentic",
-            json={"model": "llama3.2:1b"}
-        )
+        response = client.post("/api/v1/ask-agentic", json={"model": "llama3.2:1b"})
 
         assert response.status_code == 422
 
@@ -110,10 +99,7 @@ class TestAgenticAskEndpoint:
         """Test agentic RAG when service raises exception."""
         mock_agentic_rag_service.ask = AsyncMock(side_effect=Exception("Service error"))
 
-        response = client.post(
-            "/api/v1/ask-agentic",
-            json={"query": "Test query"}
-        )
+        response = client.post("/api/v1/ask-agentic", json={"query": "Test query"})
 
         assert response.status_code == 500
         data = response.json()
@@ -121,19 +107,18 @@ class TestAgenticAskEndpoint:
 
     def test_ask_agentic_with_sources(self, client, mock_agentic_rag_service):
         """Test that sources are properly returned in response."""
-        mock_agentic_rag_service.ask = AsyncMock(return_value={
-            "query": "What is transformer architecture?",
-            "answer": "Transformers use self-attention mechanisms.",
-            "sources": ["https://arxiv.org/pdf/1706.03762.pdf"],
-            "reasoning_steps": ["Retrieved papers", "Generated answer"],
-            "retrieval_attempts": 1,
-            "rewritten_query": None,
-        })
-
-        response = client.post(
-            "/api/v1/ask-agentic",
-            json={"query": "What is transformer architecture?"}
+        mock_agentic_rag_service.ask = AsyncMock(
+            return_value={
+                "query": "What is transformer architecture?",
+                "answer": "Transformers use self-attention mechanisms.",
+                "sources": ["https://arxiv.org/pdf/1706.03762.pdf"],
+                "reasoning_steps": ["Retrieved papers", "Generated answer"],
+                "retrieval_attempts": 1,
+                "rewritten_query": None,
+            }
         )
+
+        response = client.post("/api/v1/ask-agentic", json={"query": "What is transformer architecture?"})
 
         assert response.status_code == 200
         data = response.json()
@@ -142,24 +127,23 @@ class TestAgenticAskEndpoint:
 
     def test_ask_agentic_reasoning_steps(self, client, mock_agentic_rag_service):
         """Test that reasoning steps are included in response."""
-        mock_agentic_rag_service.ask = AsyncMock(return_value={
-            "query": "What is deep learning?",
-            "answer": "Deep learning is...",
-            "sources": [],
-            "reasoning_steps": [
-                "Query validation passed",
-                "Retrieved 3 papers",
-                "Graded documents as relevant",
-                "Generated final answer"
-            ],
-            "retrieval_attempts": 1,
-            "rewritten_query": None,
-        })
-
-        response = client.post(
-            "/api/v1/ask-agentic",
-            json={"query": "What is deep learning?"}
+        mock_agentic_rag_service.ask = AsyncMock(
+            return_value={
+                "query": "What is deep learning?",
+                "answer": "Deep learning is...",
+                "sources": [],
+                "reasoning_steps": [
+                    "Query validation passed",
+                    "Retrieved 3 papers",
+                    "Graded documents as relevant",
+                    "Generated final answer",
+                ],
+                "retrieval_attempts": 1,
+                "rewritten_query": None,
+            }
         )
+
+        response = client.post("/api/v1/ask-agentic", json={"query": "What is deep learning?"})
 
         assert response.status_code == 200
         data = response.json()
@@ -168,19 +152,18 @@ class TestAgenticAskEndpoint:
 
     def test_ask_agentic_with_rewritten_query(self, client, mock_agentic_rag_service):
         """Test response when query was rewritten."""
-        mock_agentic_rag_service.ask = AsyncMock(return_value={
-            "query": "ML stuff",
-            "answer": "Machine learning...",
-            "sources": [],
-            "reasoning_steps": ["Query rewritten", "Retrieved papers"],
-            "retrieval_attempts": 2,
-            "rewritten_query": "What are the key concepts in machine learning?",
-        })
-
-        response = client.post(
-            "/api/v1/ask-agentic",
-            json={"query": "ML stuff"}
+        mock_agentic_rag_service.ask = AsyncMock(
+            return_value={
+                "query": "ML stuff",
+                "answer": "Machine learning...",
+                "sources": [],
+                "reasoning_steps": ["Query rewritten", "Retrieved papers"],
+                "retrieval_attempts": 2,
+                "rewritten_query": "What are the key concepts in machine learning?",
+            }
         )
+
+        response = client.post("/api/v1/ask-agentic", json={"query": "ML stuff"})
 
         assert response.status_code == 200
         data = response.json()
@@ -189,13 +172,7 @@ class TestAgenticAskEndpoint:
 
     def test_ask_agentic_custom_model(self, client, mock_agentic_rag_service):
         """Test agentic RAG with custom model parameter."""
-        response = client.post(
-            "/api/v1/ask-agentic",
-            json={
-                "query": "What is AI?",
-                "model": "llama3.2:3b"
-            }
-        )
+        response = client.post("/api/v1/ask-agentic", json={"query": "What is AI?", "model": "llama3.2:3b"})
 
         assert response.status_code == 200
         # Verify the service was called with the custom model
@@ -205,13 +182,7 @@ class TestAgenticAskEndpoint:
 
     def test_ask_agentic_search_mode_hybrid(self, client, mock_agentic_rag_service):
         """Test that search_mode is set correctly for hybrid search."""
-        response = client.post(
-            "/api/v1/ask-agentic",
-            json={
-                "query": "What is AI?",
-                "use_hybrid": True
-            }
-        )
+        response = client.post("/api/v1/ask-agentic", json={"query": "What is AI?", "use_hybrid": True})
 
         assert response.status_code == 200
         data = response.json()
@@ -219,13 +190,7 @@ class TestAgenticAskEndpoint:
 
     def test_ask_agentic_search_mode_bm25(self, client, mock_agentic_rag_service):
         """Test that search_mode is set correctly for BM25 search."""
-        response = client.post(
-            "/api/v1/ask-agentic",
-            json={
-                "query": "What is AI?",
-                "use_hybrid": False
-            }
-        )
+        response = client.post("/api/v1/ask-agentic", json={"query": "What is AI?", "use_hybrid": False})
 
         assert response.status_code == 200
         data = response.json()

--- a/tests/unit/services/agents/test_agentic_rag.py
+++ b/tests/unit/services/agents/test_agentic_rag.py
@@ -1,9 +1,9 @@
 """Tests for AgenticRAGService using LangGraph 2.0 Runtime pattern."""
 
-import pytest
 from unittest.mock import AsyncMock, Mock
-from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from src.services.agents.agentic_rag import AgenticRAGService
 from src.services.agents.config import GraphConfig
 from src.services.agents.models import GuardrailScoring

--- a/tests/unit/services/agents/test_models.py
+++ b/tests/unit/services/agents/test_models.py
@@ -1,14 +1,13 @@
 import pytest
 from pydantic import ValidationError
-
 from src.services.agents.models import (
-    GuardrailScoring,
     GradeDocuments,
+    GradingResult,
+    GuardrailScoring,
+    ReasoningStep,
+    RoutingDecision,
     SourceItem,
     ToolArtefact,
-    RoutingDecision,
-    GradingResult,
-    ReasoningStep,
 )
 
 
@@ -75,7 +74,7 @@ class TestSourceItem:
             title="Attention Is All You Need",
             authors=["Vaswani, A.", "Shazeer, N."],
             url="https://arxiv.org/abs/1706.03762",
-            relevance_score=0.95
+            relevance_score=0.95,
         )
         assert source.arxiv_id == "1706.03762"
         assert source.title == "Attention Is All You Need"
@@ -85,11 +84,7 @@ class TestSourceItem:
 
     def test_default_values(self):
         """Test default field values."""
-        source = SourceItem(
-            arxiv_id="1234.5678",
-            title="Test Paper",
-            url="https://arxiv.org/abs/1234.5678"
-        )
+        source = SourceItem(arxiv_id="1234.5678", title="Test Paper", url="https://arxiv.org/abs/1234.5678")
         assert source.authors == []
         assert source.relevance_score == 0.0
 
@@ -100,7 +95,7 @@ class TestSourceItem:
             title="Attention Is All You Need",
             authors=["Vaswani, A."],
             url="https://arxiv.org/abs/1706.03762",
-            relevance_score=0.95
+            relevance_score=0.95,
         )
         source_dict = source.to_dict()
 
@@ -121,7 +116,7 @@ class TestToolArtefact:
             tool_name="retrieve_papers",
             tool_call_id="call_123",
             content="Retrieved 3 papers",
-            metadata={"count": 3, "source": "opensearch"}
+            metadata={"count": 3, "source": "opensearch"},
         )
         assert artefact.tool_name == "retrieve_papers"
         assert artefact.tool_call_id == "call_123"
@@ -130,11 +125,7 @@ class TestToolArtefact:
 
     def test_default_metadata(self):
         """Test default empty metadata."""
-        artefact = ToolArtefact(
-            tool_name="test_tool",
-            tool_call_id="call_456",
-            content="Test content"
-        )
+        artefact = ToolArtefact(tool_name="test_tool", tool_call_id="call_456", content="Test content")
         assert artefact.metadata == {}
 
 
@@ -167,10 +158,7 @@ class TestGradingResult:
     def test_valid_grading_result(self):
         """Test creating valid grading result."""
         result = GradingResult(
-            document_id="doc_123",
-            is_relevant=True,
-            score=0.87,
-            reasoning="Contains relevant information about transformers"
+            document_id="doc_123", is_relevant=True, score=0.87, reasoning="Contains relevant information about transformers"
         )
         assert result.document_id == "doc_123"
         assert result.is_relevant is True
@@ -179,10 +167,7 @@ class TestGradingResult:
 
     def test_default_values(self):
         """Test default field values."""
-        result = GradingResult(
-            document_id="doc_456",
-            is_relevant=False
-        )
+        result = GradingResult(document_id="doc_456", is_relevant=False)
         assert result.score == 0.0
         assert result.reasoning == ""
 
@@ -195,7 +180,7 @@ class TestReasoningStep:
         step = ReasoningStep(
             step_name="retrieve",
             description="Retrieved 3 relevant papers from OpenSearch",
-            metadata={"num_docs": 3, "retrieval_time_ms": 150}
+            metadata={"num_docs": 3, "retrieval_time_ms": 150},
         )
         assert step.step_name == "retrieve"
         assert step.description == "Retrieved 3 relevant papers from OpenSearch"
@@ -204,8 +189,5 @@ class TestReasoningStep:
 
     def test_default_metadata(self):
         """Test default empty metadata."""
-        step = ReasoningStep(
-            step_name="generate",
-            description="Generated final answer"
-        )
+        step = ReasoningStep(step_name="generate", description="Generated final answer")
         assert step.metadata == {}

--- a/tests/unit/services/agents/test_nodes.py
+++ b/tests/unit/services/agents/test_nodes.py
@@ -1,20 +1,20 @@
 """Tests for agentic RAG node functions using Runtime[Context] pattern."""
 
-import pytest
 from unittest.mock import AsyncMock, Mock
+
+import pytest
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langgraph.runtime import Runtime
-
+from src.services.agents.models import GradeDocuments, GuardrailScoring
 from src.services.agents.nodes import (
-    ainvoke_retrieve_step,
-    ainvoke_grade_documents_step,
-    ainvoke_rewrite_query_step,
     ainvoke_generate_answer_step,
+    ainvoke_grade_documents_step,
     ainvoke_out_of_scope_step,
+    ainvoke_retrieve_step,
+    ainvoke_rewrite_query_step,
     continue_after_guardrail,
 )
-from src.services.agents.nodes.utils import get_latest_query, get_latest_context
-from src.services.agents.models import GuardrailScoring, GradeDocuments
+from src.services.agents.nodes.utils import get_latest_context, get_latest_query
 from src.services.agents.state import AgentState
 
 
@@ -98,10 +98,9 @@ class TestGradeDocumentsNode:
     async def test_grade_documents_relevant(self, test_context, sample_human_message, sample_tool_message):
         """Test grading node with relevant documents."""
         mock_llm = Mock()
-        mock_llm.ainvoke = AsyncMock(return_value=GradeDocuments(
-            binary_score="yes",
-            reasoning="Document discusses transformers which is relevant"
-        ))
+        mock_llm.ainvoke = AsyncMock(
+            return_value=GradeDocuments(binary_score="yes", reasoning="Document discusses transformers which is relevant")
+        )
         test_context.ollama_client.create_llm = Mock(return_value=mock_llm)
 
         state: AgentState = {
@@ -119,10 +118,9 @@ class TestGradeDocumentsNode:
     async def test_grade_documents_not_relevant(self, test_context, sample_human_message, sample_tool_message):
         """Test grading node with irrelevant documents."""
         mock_llm = Mock()
-        mock_llm.ainvoke = AsyncMock(return_value=GradeDocuments(
-            binary_score="no",
-            reasoning="Document is not relevant to the query"
-        ))
+        mock_llm.ainvoke = AsyncMock(
+            return_value=GradeDocuments(binary_score="no", reasoning="Document is not relevant to the query")
+        )
         test_context.ollama_client.create_llm = Mock(return_value=mock_llm)
 
         state: AgentState = {
@@ -144,9 +142,9 @@ class TestRewriteQueryNode:
     async def test_rewrite_query_success(self, test_context, sample_human_message):
         """Test query rewriting with LLM."""
         mock_llm = Mock()
-        mock_llm.ainvoke = AsyncMock(return_value=Mock(
-            content="What are the key concepts in transformer neural network architectures?"
-        ))
+        mock_llm.ainvoke = AsyncMock(
+            return_value=Mock(content="What are the key concepts in transformer neural network architectures?")
+        )
         test_context.ollama_client.create_llm = Mock(return_value=mock_llm)
 
         state: AgentState = {
@@ -171,9 +169,9 @@ class TestGenerateAnswerNode:
     async def test_generate_answer_success(self, test_context, sample_human_message, sample_tool_message):
         """Test answer generation with context."""
         mock_llm = Mock()
-        mock_llm.ainvoke = AsyncMock(return_value=Mock(
-            content="Based on the papers, transformers are neural network architectures."
-        ))
+        mock_llm.ainvoke = AsyncMock(
+            return_value=Mock(content="Based on the papers, transformers are neural network architectures.")
+        )
         test_context.ollama_client.create_llm = Mock(return_value=mock_llm)
 
         state: AgentState = {
@@ -197,9 +195,7 @@ class TestOutOfScopeNode:
     async def test_out_of_scope_response(self, test_context, sample_human_message):
         """Test out-of-scope helpful rejection."""
         mock_llm = Mock()
-        mock_llm.ainvoke = AsyncMock(return_value=Mock(
-            content="I'm designed to help with AI research papers."
-        ))
+        mock_llm.ainvoke = AsyncMock(return_value=Mock(content="I'm designed to help with AI research papers."))
         test_context.ollama_client.create_llm = Mock(return_value=mock_llm)
 
         state: AgentState = {

--- a/tests/unit/services/agents/test_tools.py
+++ b/tests/unit/services/agents/test_tools.py
@@ -1,7 +1,7 @@
-import pytest
 from unittest.mock import AsyncMock
-from langchain_core.documents import Document
 
+import pytest
+from langchain_core.documents import Document
 from src.services.agents.tools import create_retriever_tool
 
 
@@ -49,6 +49,7 @@ async def test_create_retriever_tool_basic(mock_opensearch_client, mock_jina_emb
 async def test_retriever_tool_empty_results(mock_opensearch_client, mock_jina_embeddings_client):
     """Test retriever tool with no results."""
     from unittest.mock import Mock
+
     mock_opensearch_client.search_unified = Mock(return_value={"hits": []})
 
     tool = create_retriever_tool(
@@ -84,18 +85,21 @@ async def test_retriever_tool_custom_top_k(mock_opensearch_client, mock_jina_emb
 async def test_retriever_tool_metadata_fields(mock_opensearch_client, mock_jina_embeddings_client):
     """Test that all expected metadata fields are present."""
     from unittest.mock import Mock
-    mock_opensearch_client.search_unified = Mock(return_value={
-        "hits": [
-            {
-                "chunk_text": "Test content",
-                "arxiv_id": "2301.00001",
-                "title": "Test Paper",
-                "authors": "Author One, Author Two",
-                "score": 0.95,
-                "section_name": "Introduction",
-            }
-        ]
-    })
+
+    mock_opensearch_client.search_unified = Mock(
+        return_value={
+            "hits": [
+                {
+                    "chunk_text": "Test content",
+                    "arxiv_id": "2301.00001",
+                    "title": "Test Paper",
+                    "authors": "Author One, Author Two",
+                    "score": 0.95,
+                    "section_name": "Introduction",
+                }
+            ]
+        }
+    )
 
     tool = create_retriever_tool(
         opensearch_client=mock_opensearch_client,

--- a/uv.lock
+++ b/uv.lock
@@ -900,6 +900,18 @@ wheels = [
 ]
 
 [[package]]
+name = "grandalf"
+version = "0.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/0e/4ac934b416857969f9135dec17ac80660634327e003a870835dd1f382659/grandalf-0.8.tar.gz", hash = "sha256:2813f7aab87f0d20f334a3162ccfbcbf085977134a17a5b516940a93a77ea974", size = 38128, upload-time = "2023-01-26T07:37:06.668Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/30/44c7eb0a952478dbb5f2f67df806686d6a7e4b19f6204e091c4f49dc7c69/grandalf-0.8-py3-none-any.whl", hash = "sha256:793ca254442f4a79252ea9ff1ab998e852c1e071b863593e5383afee906b4185", size = 41802, upload-time = "2023-01-10T15:16:19.753Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.2.4"
 source = { registry = "https://pypi.org/simple" }
@@ -913,6 +925,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
     { url = "https://files.pythonhosted.org/packages/3f/c7/12381b18e21aef2c6bd3a636da1088b888b97b7a0362fac2e4de92405f97/greenlet-3.2.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:20fb936b4652b6e307b8f347665e2c615540d4b42b3b4c8a321d8286da7e520f", size = 1151142, upload-time = "2025-08-07T13:18:22.981Z" },
+    { url = "https://files.pythonhosted.org/packages/27/45/80935968b53cfd3f33cf99ea5f08227f2646e044568c9b1555b58ffd61c2/greenlet-3.2.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ee7a6ec486883397d70eec05059353b8e83eca9168b9f3f9a361971e77e0bcd0", size = 1564846, upload-time = "2025-11-04T12:42:15.191Z" },
+    { url = "https://files.pythonhosted.org/packages/69/02/b7c30e5e04752cb4db6202a3858b149c0710e5453b71a3b2aec5d78a1aab/greenlet-3.2.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:326d234cbf337c9c3def0676412eb7040a35a768efc92504b947b3e9cfc7543d", size = 1633814, upload-time = "2025-11-04T12:42:17.175Z" },
     { url = "https://files.pythonhosted.org/packages/e9/08/b0814846b79399e585f974bbeebf5580fbe59e258ea7be64d9dfb253c84f/greenlet-3.2.4-cp312-cp312-win_amd64.whl", hash = "sha256:a7d4e128405eea3814a12cc2605e0e6aedb4035bf32697f72deca74de4105e02", size = 299899, upload-time = "2025-08-07T13:38:53.448Z" },
 ]
 
@@ -1579,6 +1593,19 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-ollama"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "ollama" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/51/72cd04d74278f3575f921084f34280e2f837211dc008c9671c268c578afe/langchain_ollama-1.0.1.tar.gz", hash = "sha256:e37880c2f41cdb0895e863b1cfd0c2c840a117868b3f32e44fef42569e367443", size = 153850, upload-time = "2025-12-12T21:48:28.68Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/46/f2907da16dc5a5a6c679f83b7de21176178afad8d2ca635a581429580ef6/langchain_ollama-1.0.1-py3-none-any.whl", hash = "sha256:37eb939a4718a0255fe31e19fbb0def044746c717b01b97d397606ebc3e9b440", size = 29207, upload-time = "2025-12-12T21:48:27.832Z" },
+]
+
+[[package]]
 name = "langchain-text-splitters"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1846,6 +1873,7 @@ dependencies = [
     { name = "langchain" },
     { name = "langchain-community" },
     { name = "langchain-core" },
+    { name = "langchain-ollama" },
     { name = "langfuse" },
     { name = "langgraph" },
     { name = "opensearch-py" },
@@ -1880,6 +1908,9 @@ dev = [
     { name = "testcontainers" },
     { name = "types-sqlalchemy" },
 ]
+viz = [
+    { name = "grandalf" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1891,7 +1922,8 @@ requires-dist = [
     { name = "langchain", specifier = ">=0.3.0" },
     { name = "langchain-community", specifier = ">=0.3.0" },
     { name = "langchain-core", specifier = ">=0.3.0" },
-    { name = "langfuse", specifier = ">=3.0.0,<4.0.0" },
+    { name = "langchain-ollama", specifier = ">=0.3.0" },
+    { name = "langfuse", specifier = ">=3.0.0" },
     { name = "langgraph", specifier = ">=0.2.0" },
     { name = "opensearch-py", specifier = ">=3.0.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },
@@ -1925,6 +1957,7 @@ dev = [
     { name = "testcontainers", specifier = ">=4.10.0" },
     { name = "types-sqlalchemy", specifier = ">=1.4.53.38" },
 ]
+viz = [{ name = "grandalf", specifier = ">=0.8" }]
 
 [[package]]
 name = "mpire"
@@ -2305,6 +2338,19 @@ version = "12.8.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
+]
+
+[[package]]
+name = "ollama"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/72/5f12423b6b39ca8430fbe56f77fcf4ef60f63067c7c4a2e30e200ed9ec16/ollama-0.6.2.tar.gz", hash = "sha256:936d55daa684f474364c098611c933626f8d6c7d67065c5b7ae0c477b508b07f", size = 53145, upload-time = "2026-04-29T21:21:15.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/ab/d6722beeb2d10f7a3b9ff49375708904fde18f82b5609a0bc4aeb5996a4d/ollama-0.6.2-py3-none-any.whl", hash = "sha256:3ad7daab28e5a973445c36a73882a3ef698c2ebb00e21e308652741577509f7d", size = 15115, upload-time = "2026-04-29T21:21:13.794Z" },
 ]
 
 [[package]]
@@ -2859,6 +2905,15 @@ name = "pylatexenc"
 version = "2.10"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5d/ab/34ec41718af73c00119d0351b7a2531d2ebddb51833a36448fc7b862be60/pylatexenc-2.10.tar.gz", hash = "sha256:3dd8fd84eb46dc30bee1e23eaab8d8fb5a7f507347b23e5f38ad9675c84f40d3", size = 162597, upload-time = "2021-04-06T07:56:07.854Z" }
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
 
 [[package]]
 name = "pypdfium2"


### PR DESCRIPTION
## Summary

Adds a complete, native Claude Code setup to this repo, which doubles as the syllabus for the 2-hour **Claude Code workshop** (`docs/workshop/claude-code-workshop.md`):

- **CLAUDE.md** — commands, architecture map, conventions, quality gates, workflow policy
- **`.claude/settings.json`** — PostToolUse pre-commit hook + permissions allowlist
- **11 skills** — `write-a-prd` / `work-issue` / `local-ci` workflow trio; `audit`; `generate-tests`; retrieval-experiment suite (`setup-experiment`, `offline-eval`, `cleanup-experiment`, `list-experiments`); `brainstorming`; `grill-me`
- **3 legacy commands** (`create-pr`, `fix-ci`, `daily-standup`) for the skills-vs-commands demo
- **`.github/workflows/ci.yml`** — first CI for this repo: ruff + mypy + hermetic unit tests
- **`.gitignore`** — track `.claude/` artifacts; keep personal files ignored

Plus two enabling commits:
1. `fix`: #28 made `DoclingParser.parse_pdf` synchronous but `PDFParserService` still awaited it — every PDF parse raised `PDFParsingException` (2 unit tests were failing on main)
2. `chore`: mechanical `ruff check --fix` + `ruff format` so CI is green from its first run

## Notes

- CI runs hermetic unit tests only; `tests/api` + `tests/integration` need live services and run via `/local-ci`. `tests/unit/services/agents` is excluded until the Week 7 stabilization lands, then re-enable.
- Exceeds the 500-line auto-merge limit by design → human review required.

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — 121 files formatted
- [x] `uv run mypy src/` — clean
- [x] `uv run pytest tests/unit --ignore=tests/unit/services/agents` — 48 passed
- [x] `tests/unit/services/test_pdf_parser.py` — 12 passed (was 2 failing on main)
- [x] Anonymization sweep over all new docs — clean
- [ ] CI green on this PR (first-ever Actions run for the repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)