### PR TITLE
Fix: Update notebook password extraction to align with Airflow 2.10.3

### DIFF
--- a/airflow/entrypoint.sh
+++ b/airflow/entrypoint.sh
@@ -25,7 +25,10 @@ airflow users create \
     --email admin@example.com \
     --password admin || echo "Admin user already exists"
 
-# Start webserver and scheduler
-echo "Starting Airflow webserver and scheduler..."
-airflow webserver --port 8080 --daemon &
-airflow scheduler
+# Start scheduler in the background
+echo "Starting Airflow scheduler..."
+airflow scheduler &
+
+# Start webserver in the foreground (keeps container alive)
+echo "Starting Airflow webserver..."
+exec airflow webserver --port 8080


### PR DESCRIPTION
Fixes #23 

## Summary

Fixes two issues that prevent Airflow from being accessible out of the box:

1. **Password retrieval fails** — the notebook code assumes Airflow 3.0 and looks for a file that doesn't exist
2. **Webserver crashes on restart** — daemon mode creates stale PID files that block the webserver from starting

---

## Issue 1: Airflow password not found (`⚠ Password file not found`)

The notebook cell in `week1.ipynb` attempts to retrieve the admin password like this:

```python
password_file = project_root / "airflow" / "simple_auth_manager_passwords.json.generated"
```

This will **always fail** for two reasons:

### Wrong Airflow version assumption

The file `simple_auth_manager_passwords.json.generated` is an **Airflow 3.0** feature where the Simple Auth Manager auto-generates passwords into a JSON file. However, this project uses **Airflow 2.10.3** (defined in `airflow/Dockerfile`):

```dockerfile
ENV AIRFLOW_VERSION=2.10.3
```

Airflow 2.x uses traditional user management via `airflow users create` with an explicit `--password` flag, as seen in `airflow/entrypoint.sh`:

```bash
airflow users create \
    --username admin \
    --password admin ...
```

There is no auto-generated password file in Airflow 2.x — the password is `admin`, set directly in the entrypoint script.

### Wrong file location — looking on host instead of container

Even if this project **were** using Airflow 3.0, the code would still fail. The notebook runs on the **host machine** and looks for the file at:

```
<project_root>/airflow/simple_auth_manager_passwords.json.generated
```

But Airflow runs **inside a Docker container**, where the file (if it existed) would be at:

```
/opt/airflow/simple_auth_manager_passwords.json.generated
```

The host filesystem cannot access container-internal files through a local path.

| | Original Code | Reality |
|---|---|---|
| **Airflow version** | Assumes 3.0 | Actually 2.10.3 |
| **Password method** | Auto-generated JSON file | Explicit `--password` in entrypoint.sh |
| **File location** | Looks on host filesystem | File would be inside Docker container |
| **Password** | Tries to read from nonexistent file | It's `admin`, set in entrypoint.sh |

### Fix

Updated the notebook cell to query the running container directly using docker exec to verify the admin user exists, then extract the actual password from the entrypoint script inside the container:

```python
result = subprocess.run(
    ["docker", "exec", "rag-airflow", "cat", "/entrypoint.sh"],
    capture_output=True, text=True, timeout=15
)
# Parse --password value from entrypoint.sh
match = re.search(r'--password\s+(\S+)', result.stdout)
```

This approach works correctly with Airflow 2.x and reads from the container where Airflow actually runs.

---

## Issue 2: Webserver unreachable (`localhost:8080` not responding)

The original `entrypoint.sh` starts the webserver as a **daemon**:

```bash
airflow webserver --port 8080 --daemon &
airflow scheduler
```

The `--daemon` flag creates a PID file (`airflow-webserver.pid`). On container restart, the stale PID file persists and the webserver refuses to start:

```
AirflowException: The webserver is already running under PID 23.
```

### Fix

Swapped the foreground/background roles — scheduler runs in the background, webserver runs in the foreground with `exec`:

```bash
airflow scheduler &
exec airflow webserver --port 8080
```

No PID file is created, and `exec` makes the webserver PID 1 for proper Docker signal handling.

---

## Files Changed

- **`week1.ipynb`** — Fixed Airflow password retrieval cell to work with Airflow 2.x by querying the container directly instead of looking for a nonexistent Airflow 3.0 password file on the host
- **`airflow/entrypoint.sh`** — Run webserver in foreground instead of daemon mode to prevent stale PID file crashes on container restart

## Testing

- ✅ Password retrieval cell correctly outputs `✓ Airflow password found: admin`
- ✅ Webserver responds on `localhost:8080` (health check returns HTTP 200)
- ✅ Container survives `docker restart rag-airflow` without PID conflicts
- ✅ Admin login works with `admin/admin` credentials
- ✅ Scheduler runs correctly in the background
