### PR TITLE
fix: update langfuse container healthchecks (replace curl with wget and add worker check)

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -241,6 +241,12 @@ services:
       REDIS_PORT: 6379
       REDIS_AUTH: ${LANGFUSE_REDIS_PASSWORD}
       REDIS_TLS_ENABLED: "false"
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep -f 'worker/dist/index.js' >/dev/null || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
     networks:
       - rag-network
 
@@ -299,7 +305,7 @@ services:
       LANGFUSE_INIT_USER_NAME: "Admin User"
       LANGFUSE_INIT_USER_PASSWORD: "admin123"
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:3000/api/public/health || exit 1"]
+      test: ["CMD-SHELL", "wget --spider -q http://$(hostname):3000/api/public/health || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 5


### PR DESCRIPTION

## Summary

Fixes broken and missing healthchecks for the Langfuse services in `compose.yml`:

1. **`langfuse-web`** — Replace `curl` (not installed) with `wget` (pre-installed) so the healthcheck actually works
2. **`langfuse-worker`** — Add a missing healthcheck to detect when the worker process crashes

---

## Problem

### `langfuse-web`: Healthcheck silently fails

The current healthcheck uses `curl`:

```yaml
test: ["CMD-SHELL", "curl -f http://localhost:3000/api/public/health || exit 1"]
```

The Langfuse Docker image (`langfuse/langfuse:3`) is based on **Node.js**, which does **not include `curl`**. This means:

- The healthcheck command fails every single run (command not found)
- Docker never receives a successful health probe
- The container is permanently stuck in `starting` or marked `unhealthy`
- Any service with `depends_on: condition: service_healthy` pointing to `langfuse-web` may fail to start or behave unpredictably

### `langfuse-worker`: No healthcheck at all

The `langfuse-worker` service has **no healthcheck defined**. Docker has no way to detect if the internal worker process (`worker/dist/index.js`) has crashed. The container shows as "running" even when the worker has silently died, leading to:

- Unprocessed background jobs (event ingestion, scoring, etc.)
- No automatic recovery or alerting
- Difficult debugging — the container appears healthy when it isn't

---

## Fix

### `langfuse-web` — Use `wget` instead of `curl`

```diff
- test: ["CMD-SHELL", "curl -f http://localhost:3000/api/public/health || exit 1"]
+ test: ["CMD-SHELL", "wget --spider -q http://$(hostname):3000/api/public/health || exit 1"]
```

- **`wget`** is available in the Langfuse base image, unlike `curl`
- **`--spider`** performs a HEAD request without downloading the body (lightweight)
- **`-q`** suppresses output for clean logs
- **`$(hostname)`** resolves to the container's own hostname, which is more reliable than `localhost` in some Docker network configurations

### `langfuse-worker` — Add process-based healthcheck

```yaml
healthcheck:
  test: ["CMD-SHELL", "pgrep -f 'worker/dist/index.js' >/dev/null || exit 1"]
  interval: 30s
  timeout: 10s
  retries: 5
  start_period: 60s
```

- **`pgrep -f`** checks if the worker process is alive by searching for the `worker/dist/index.js` process
- **`start_period: 60s`** gives the worker time to initialize before health checks begin
- If the worker crashes, Docker will mark the container as `unhealthy` for proper monitoring and orchestration

---

## Files Changed

- **`compose.yml`** — Two changes in the Langfuse services:
  - `langfuse-web`: Replaced `curl` healthcheck with `wget`
  - `langfuse-worker`: Added healthcheck block (previously had none)

## Testing

- ✅ `langfuse-web` healthcheck passes — container reaches `healthy` state
- ✅ `langfuse-worker` healthcheck passes — worker process is detected
- ✅ No changes to ports, volumes, environment variables, or other service configurations
- ✅ Services that depend on `langfuse-web` or `langfuse-worker` with `condition: service_healthy` now work reliably
