### PR TITLE
fix(airflow): install CPU-only torch to avoid multi-GB CUDA wheels

### DIFF
--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -34,6 +34,10 @@ RUN pip install --no-cache-dir \
     --constraint "${CONSTRAINT_URL}" \
     psycopg2-binary
 
+# Install CPU-only PyTorch first so docling doesn't pull multi-GB CUDA wheels
+# (Linux wheels on PyPI bundle full CUDA binaries by default)
+RUN pip install --no-cache-dir torch torchvision --index-url https://download.pytorch.org/whl/cpu
+
 # Copy requirements and install project dependencies
 COPY requirements-airflow.txt /tmp/requirements-airflow.txt
 RUN pip install --no-cache-dir -r /tmp/requirements-airflow.txt


### PR DESCRIPTION
Fixes #41

## Problem
Building the Airflow image on Linux pulls several gigabytes of NVIDIA CUDA dependencies, because `docling` depends on `torch`/`torchvision` and the default PyPI Linux wheels bundle full CUDA binaries (cuDNN, cuBLAS, NCCL, etc. as `nvidia-*` packages).

## Fix
Pre-install `torch` and `torchvision` from the official PyTorch CPU wheel index before installing `requirements-airflow.txt`. When pip later resolves docling's dependencies, torch is already satisfied by the CPU build, so the CUDA wheels are never downloaded.

## Verification
Built the image and confirmed inside the container:

```
torch 2.13.0+cpu
torchvision 0.28.0+cpu
cuda available: False
```

`from docling.document_converter import DocumentConverter` imports cleanly.

## Image size
- With this fix (CPU-only torch): **3.52 GB** (measured)
- Without the fix (CUDA torch): the `nvidia-*` package stack adds roughly **6–8 GB** on top, putting the image around **~10 GB** (estimated from wheel sizes)